### PR TITLE
(chocolatey-core.extension) Changed key to be single value

### DIFF
--- a/extensions/chocolatey-core.extension/CHANGELOG.md
+++ b/extensions/chocolatey-core.extension/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.3.4
+- Bugfix `Get-AppInstallLocation`: Changed key to be forced as a single value (instead of array)
+
 ## 1.3.3
 
 - Bugfix `Get-AppInstallLocation`: fix path is directory

--- a/extensions/chocolatey-core.extension/chocolatey-core.extension.nuspec
+++ b/extensions/chocolatey-core.extension/chocolatey-core.extension.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>chocolatey-core.extension</id>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
     <title>Chocolatey Core Extensions</title>
     <summary>Helper functions extending core choco functionality</summary>
     <authors>chocolatey</authors>

--- a/extensions/chocolatey-core.extension/extensions/Get-AppInstallLocation.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-AppInstallLocation.ps1
@@ -40,8 +40,8 @@ function Get-AppInstallLocation {
     $ErrorActionPreference = "SilentlyContinue"
 
     Write-Verbose "Trying local and machine (x32 & x64) Uninstall keys"
-    [array] $key = Get-UninstallRegistryKey $AppNamePattern
-    if ($key.Count -eq 1) {
+    $key = Get-UninstallRegistryKey $AppNamePattern | select -First 1
+    if ($key) {
         Write-Verbose "Trying Uninstall key property 'InstallLocation'"
         $location = $key.InstallLocation
         if (is_dir $location) { return strip $location }


### PR DESCRIPTION
This is a compatibility fix to make the function
compatible with Powershell V2. Without this fix
the 'UninstallString'/'InstallLocation' value
will always be null.