### PR TITLE
(chocolatey-core.extension) Unescape app name pattern when calling 'Get-UninstallRegistryKey'

### DIFF
--- a/extensions/chocolatey-core.extension/CHANGELOG.md
+++ b/extensions/chocolatey-core.extension/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.3.4
 - Bugfix `Get-AppInstallLocation`: Changed key to be forced as a single value (instead of array)
+- Bugfix `Get-AppInstallLocation`: Added unescaping of app name pattern when calling 'Get-UninstallRegistryKey' ([#784](https://github.com/chocolatey/chocolatey-coreteampackages/issues/784))
 
 ## 1.3.3
 

--- a/extensions/chocolatey-core.extension/CHANGELOG.md
+++ b/extensions/chocolatey-core.extension/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.3.4
+- Bugfix `Get-AppInstallLocation`: Changed key to be forced as a single value (instead of array)
+
 ## 1.3.3
 
 - Bugfix `Get-AppInstallLocation`: fix path is directory

--- a/extensions/chocolatey-core.extension/chocolatey-core.extension.nuspec
+++ b/extensions/chocolatey-core.extension/chocolatey-core.extension.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>chocolatey-core.extension</id>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
     <title>Chocolatey Core Extensions</title>
     <summary>Helper functions extending core choco functionality</summary>
     <authors>chocolatey</authors>

--- a/extensions/chocolatey-core.extension/extensions/Get-AppInstallLocation.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-AppInstallLocation.ps1
@@ -40,7 +40,9 @@ function Get-AppInstallLocation {
     $ErrorActionPreference = "SilentlyContinue"
 
     Write-Verbose "Trying local and machine (x32 & x64) Uninstall keys"
-    $key = Get-UninstallRegistryKey $AppNamePattern | select -First 1
+    # Needed to pass in the correct wildcard pattern to 'Get-UninstallRegistryKey'
+    $unescapedAppNamePattern = [regex]::Unescape($AppNamePattern)
+    $key = Get-UninstallRegistryKey $unescapedAppNamePattern | select -First 1
     if ($key) {
         Write-Verbose "Trying Uninstall key property 'InstallLocation'"
         $location = $key.InstallLocation

--- a/extensions/chocolatey-core.extension/extensions/Get-AppInstallLocation.ps1
+++ b/extensions/chocolatey-core.extension/extensions/Get-AppInstallLocation.ps1
@@ -40,8 +40,8 @@ function Get-AppInstallLocation {
     $ErrorActionPreference = "SilentlyContinue"
 
     Write-Verbose "Trying local and machine (x32 & x64) Uninstall keys"
-    [array] $key = Get-UninstallRegistryKey $AppNamePattern
-    if ($key.Count -eq 1) {
+    $key = Get-UninstallRegistryKey $AppNamePattern | select -First 1
+    if ($key) {
         Write-Verbose "Trying Uninstall key property 'InstallLocation'"
         $location = $key.InstallLocation
         if (is_dir $location) { return strip $location }


### PR DESCRIPTION
This is needed in some rare cases when there is an actual
need to use a regex pattern when calling 'Get-AppInstallLocation'.
fixes #784

This PR is dependent on the previous PR I opened: #1209 

Below is a list of which packages have been tested, both before the change (1.3.3) and after the change (1.3.4). Every package have been tested by installing to a custom directory (when possible), and directory not named the same as what checked for when calling `Get-AppInstallLocation`

|Package Name| Version 1.3.3 | Version 1.3.4 | Notes
|-----------:|:-------------:|:-------------:|:------|
|7zip.install|     ✔️       |      ✔️       |       |
|activepresenter|  ✔️       |      ✔️       |       |
|autohotkey.install| :x:     |      ❔       | Wrong Wildcard/Regex passed to function, probably won't match anything at all |
|avidemux    |     ❌       |       ❔       | Wrong Wildcard/Regex passed to function, only default location will match |
|cdburnerxp  |     ✔️       |       ❔       | Not picked up by parsing registry (expected), and directory can't be changed |
|clementine  |     ✔️       |       ❔       |       |
|codeblocks  |     ❔        |       ❔       |       |

More to come