### PR TITLE
(nuget.commandline) Add more streams for different 4.x versions

### DIFF
--- a/automatic/nuget.commandline/update.ps1
+++ b/automatic/nuget.commandline/update.ps1
@@ -21,12 +21,32 @@ function global:au_GetLatest {
 
   $versions = $json."nuget.exe" | Sort-Object uploaded -Descending
   $preRelease = $versions | ? stage -EQ 'EarlyAccessPreview' | select -First 1
+  $stableRelease46 = $versions | ? stage -EQ 'ReleasedAndBlessed' | ? version -like '4.6.*' | select -First 1
+  $stableRelease47 = $versions | ? stage -EQ 'ReleasedAndBlessed' | ? version -like '4.7.*' | select -First 1
+  $stableRelease48 = $versions | ? stage -EQ 'ReleasedAndBlessed' | ? version -like '4.8.*' | select -First 1
+  $stableRelease49 = $versions | ? stage -EQ 'ReleasedAndBlessed' | ? version -like '4.9.*' | select -First 1
   $stableRelease = $versions | ? stage -EQ 'ReleasedAndBlessed' | select -First 1
 
   $streams = @{
     'pre'    = @{
       Version = $preRelease.version
       URL32   = $preRelease.url
+    }
+    'stable46' = @{
+      Version = $stableRelease46.version
+      URL32   = $stableRelease46.url
+    }
+    'stable47' = @{
+      Version = $stableRelease47.version
+      URL32   = $stableRelease47.url
+    }
+    'stable48' = @{
+      Version = $stableRelease48.version
+      URL32   = $stableRelease48.url
+    }
+    'stable49' = @{
+      Version = $stableRelease49.version
+      URL32   = $stableRelease49.url
     }
     'stable' = @{
       Version = $stableRelease.version

--- a/automatic/nuget.commandline/update.ps1
+++ b/automatic/nuget.commandline/update.ps1
@@ -19,40 +19,29 @@ function global:au_BeforeUpdate {
 function global:au_GetLatest {
   $json = Invoke-WebRequest -UseBasicParsing -Uri $releases | ConvertFrom-Json
 
-  $versions = $json."nuget.exe" | Sort-Object uploaded -Descending
-  $preRelease = $versions | ? stage -EQ 'EarlyAccessPreview' | select -First 1
-  $stableRelease46 = $versions | ? stage -EQ 'ReleasedAndBlessed' | ? version -like '4.6.*' | select -First 1
-  $stableRelease47 = $versions | ? stage -EQ 'ReleasedAndBlessed' | ? version -like '4.7.*' | select -First 1
-  $stableRelease48 = $versions | ? stage -EQ 'ReleasedAndBlessed' | ? version -like '4.8.*' | select -First 1
-  $stableRelease49 = $versions | ? stage -EQ 'ReleasedAndBlessed' | ? version -like '4.9.*' | select -First 1
-  $stableRelease = $versions | ? stage -EQ 'ReleasedAndBlessed' | select -First 1
+  $versions = $json."nuget.exe"
 
-  $streams = @{
-    'pre'    = @{
-      Version = $preRelease.version
-      URL32   = $preRelease.url
-    }
-    'stable46' = @{
-      Version = $stableRelease46.version
-      URL32   = $stableRelease46.url
-    }
-    'stable47' = @{
-      Version = $stableRelease47.version
-      URL32   = $stableRelease47.url
-    }
-    'stable48' = @{
-      Version = $stableRelease48.version
-      URL32   = $stableRelease48.url
-    }
-    'stable49' = @{
-      Version = $stableRelease49.version
-      URL32   = $stableRelease49.url
-    }
-    'stable' = @{
-      Version = $stableRelease.version
-      URL32   = $stableRelease.url
+  $streams = @{}
+
+  $versions | Sort-Object uploaded -Descending | % {
+    $versionTwoPart = $_.version -replace '^(\d+\.\d+).*$','$1'
+
+    if (!$streams.ContainsKey("$versionTwoPart")) {
+      $streams.Add($versionTwoPart, @{
+        Version = $_.Version
+        URL32   = $_.url
+      })
     }
   }
+
+  $preKey = $streams.Keys | ? { $_ -match '-' } | sort -Descending | select -First 1
+  $stableKey = $streams.Keys | ? { $_ -notmatch '-' } | sort -Descending | select -First 1
+  if ($preKey) {
+    $streams.Add('pre', $streams[$preKey])
+    $streams.Remove($preKey)
+  }
+  $streams.Add('stable', $streams[$stableKey])
+  $streams.Remove($stableKey)
 
 
   return @{ Streams = $streams }


### PR DESCRIPTION
## Description
Add streams for 4.6.x, 4.7.x, 4.8.x and 4.9.x, which all contain newer versions which are not available through Chocolatey.

## Motivation and Context
Several versions of NuGet are not available from Chocolatey, including the latest blessed version 4.9.4, since the version with the latest uploaded data is 4.6.4.

## How Has this Been Tested?
Run update.ps1 locally

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).