### PR TITLE
Improve julia installer by making it silent

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ branches:
 
 environment:
   # Set au version to use or omit to use the latest. Specify branch name to use development version from Github
-  au_version: master
+  au_version:
   au_push: true
   # Use 1 to test all, or N to split testing into N groups
   au_test_groups: 4

--- a/automatic/julia/tools/chocolateyinstall.ps1
+++ b/automatic/julia/tools/chocolateyinstall.ps1
@@ -2,11 +2,12 @@
 
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
+Get-ChocolateyUnzip -FileFullPath "$toolsDir\julia-1.1.0-win32.exe" -FileFullPath64 "$toolsDir\julia-1.1.0-win64.exe"  -Destination "$toolsDir"
+
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   fileType      = 'exe'
-  file          = "$toolsDir\julia-1.1.0-win32.exe"
-  file64        = "$toolsDir\julia-1.1.0-win64.exe"
+  file          = "$toolsDir\julia-installer.exe"
 
   softwareName  = 'Julia*'
 

--- a/automatic/julia/update.ps1
+++ b/automatic/julia/update.ps1
@@ -7,8 +7,8 @@ function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 function global:au_SearchReplace {
     @{
         ".\tools\chocolateyInstall.ps1" = @{
-            "(?i)(^\s*file\s*=\s*`"[$]toolsDir\\).*"   = "`$1$($Latest.FileName32)`""
-            "(?i)(^\s*file64\s*=\s*`"[$]toolsDir\\).*" = "`$1$($Latest.FileName64)`""
+            "(?i)(.*FileFullPath\s*=\s*`"[$]toolsDir\\).*`""   = "`$1$($Latest.FileName32)`""
+            "(?i)(.*FileFullPath64\s*=\s*`"[$]toolsDir\\).*`"" = "`$1$($Latest.FileName64)`""
         }
         "$($Latest.PackageName).nuspec" = @{
             "(\<releaseNotes\>).*?(\</releaseNotes\>)" = "`${1}$($Latest.ReleaseNotes)`$2"


### PR DESCRIPTION
Make the julia installer silent for a cleaner user experience.

## Description
Silent installation of the julia package

## Motivation and Context
Although this change is not required, it makes the user experience cleaner.
In particular, the julia installer provided by julialang is actually an archive. Therefore it makes sense to first extract the exe archive and then run the msi installer.

Notes: both the 32 and 64 bit downloads extract to the same installer name.
 
Addresses: https://github.com/chocolatey-community/chocolatey-coreteampackages/issues/1266