### PR TITLE
Terminate Skype Process after Installation

### DIFF
--- a/automatic/skype/tools/chocolateyInstall.ps1
+++ b/automatic/skype/tools/chocolateyInstall.ps1
@@ -1,5 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+$terminateSkypeProcess = 'Get-Process -Name "Skype" | Stop-Process -Force'
+
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   softwareName   = 'Skype*'
@@ -11,3 +13,5 @@ $packageArgs = @{
 }
 
 Install-ChocolateyPackage @packageArgs
+
+Start-ChocolateyProcessAsAdmin -Statements $terminateSkypeProcess


### PR DESCRIPTION
Skype: After updating Skype, the software starts automatically. This is an unwanted feature/bug/behaviour.

## Description
Before executing the installation process, i've defined a termination variable that gets the process of skype. After installation, i added a "Start-ChocolateyProcessAsAdmin" that executes the contents of the termination variable. 
This way, Skype does not start after installation

## Motivation and Context
- Why is this change required? What problem does it solve?
Currently if you're updating skype, right after the update Skype is started automatically and running as admin (if i remember correctly). That is a unwanted behaviour.

The fix proposed in #1009 imho is not a good solution, because the skype process would be started as SYSTEM since chocolatey runs with SYSTEM rights. 
Unless there is a process spawned in userland that stops and starts processes with current userland rights, this should not be implemented.

- If it fixes an open issue, please link to the issue here.
This fixes #1009 

## How Has this Been Tested?
- Please describe in detail how you tested your changes.
I've created a custom choco package for our organization that works just fine.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository. 
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

(I'm sorry, i haven't done this before..)
