### PR TITLE
(msys2) fix #1286 for non-interactive installs for msys2

### DIFF
--- a/automatic/msys2/update.ps1
+++ b/automatic/msys2/update.ps1
@@ -29,7 +29,7 @@ function global:au_GetLatest {
     if ($version32 -ne $version64) { throw "x32 and x64 versions are not the same" }
 
     @{
-        Version      = "$version32.0.0"
+        Version      = "$version32.0.1"
         URL32        = $url32
         URL64        = $url64
     }


### PR DESCRIPTION
## Description
* fix chocolatey-community/chocolatey-coreteampackages#1286
* fix is isolated to only address the problem with non-interactive installed. I did not refactor code. I did not fix various minor problems I saw elsewhere. I made no changes to metadata or other fields described in the CONTRIBUTING document.
* Included a single other fix of a horrid bug that deletes all *.xz files from the root directory on the hard drive.
* The particular approach the original coder used within the semver framework is unfortunate. They used the first xxx number (xxx.yyy.zzz) as the often iterated 3rd party field, and the next two fields unused. However, to maintain version continuity, I made no changes to the approach and instead incremented the 3rd field by 1. So with this fix, the versions will be (xxx.0.1)

## Motivation and Context
* fix chocolatey-community/chocolatey-coreteampackages#1286

## How Has this Been Tested?
* Tested using Docker with clean Windows 1809 and Powershell 5.1
* Used the AU package to create the nupackage and update the scripted files
* I encourage someone with test harnesses to test on more platforms.
* Confirmed that chocolatey doesn't work with powershell (core) 6+
* Unable to test with chocolatey-test-environment due to https://github.com/chocolatey-community/chocolatey-test-environment/issues/41
* Attempted to use the `-version 2` param on powershell, but it requires a matching v2 .netframework which is not available in the Microsoft provided docker containers. I do not have other sources of old Microsoft OS's.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of the already existing code in the changed files. No new files added.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).