### PR TITLE
Opera: Add param for All Users installation. Fix syntax errors.

### DIFF
--- a/automatic/opera/tools/chocolateyInstall.ps1
+++ b/automatic/opera/tools/chocolateyInstall.ps1
@@ -6,7 +6,6 @@ $pp = Get-PackageParameters
 
 $parameters += if ($pp.NoDesktopShortcut)     { " /desktopshortcut=0"; Write-Host "Desktop shortcut won't be created" }
 $parameters += if ($pp.NoTaskbarShortcut)     { " /pintotaskbar=0"; Write-Host "Opera won't be pinned to taskbar" }
-$parameters += if ($pp.InstallAllUsers)     { " /allusers=1"; Write-Host "Install Opera for all users, and not only the current one." }
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
@@ -17,7 +16,7 @@ $packageArgs = @{
   checksum64     = '301ea4ece36b68631c90b26c8c3e3f54e4ec23e826febd594398cca508e75819'
   checksumType   = 'sha256'
   checksumType64 = 'sha256'
-  silentArgs     = '/install /silent /launchopera=0 /setdefaultbrowser=0' + $parameters
+  silentArgs     = '/install /silent /launchopera=0 /setdefaultbrowser=0 /allusers=1' + $parameters
   validExitCodes = @(0)
 }
 

--- a/automatic/opera/tools/chocolateyInstall.ps1
+++ b/automatic/opera/tools/chocolateyInstall.ps1
@@ -4,8 +4,9 @@ $toolsPath = (Split-Path -Parent $MyInvocation.MyCommand.Definition)
 
 $pp = Get-PackageParameters
 
-$parameters += if ($pp.NoDesktopShortcut)     { " /desktopshortcut 0"; Write-Host "Desktop shortcut won't be created" }
-$parameters += if ($pp.NoTaskbarShortcut)     { " /pintotaskbar 0"; Write-Host "Opera won't be pinned to taskbar" }
+$parameters += if ($pp.NoDesktopShortcut)     { " /desktopshortcut=0"; Write-Host "Desktop shortcut won't be created" }
+$parameters += if ($pp.NoTaskbarShortcut)     { " /pintotaskbar=0"; Write-Host "Opera won't be pinned to taskbar" }
+$parameters += if ($pp.InstallAllUsers)     { " /allusers=1"; Write-Host "Install Opera for all users, and not only the current one." }
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
@@ -16,7 +17,7 @@ $packageArgs = @{
   checksum64     = '301ea4ece36b68631c90b26c8c3e3f54e4ec23e826febd594398cca508e75819'
   checksumType   = 'sha256'
   checksumType64 = 'sha256'
-  silentArgs     = '/install /silent /launchopera 0 /setdefaultbrowser 0' + $parameters
+  silentArgs     = '/install /silent /launchopera=0 /setdefaultbrowser=0' + $parameters
   validExitCodes = @(0)
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->
1. Add /InstallAllUsers parameter to switch to a system-wide install.
1. Fix syntax errors where a value for an installer argument is provided; the help information obtained directly from the Opera installer (execute it with --help as the argument) indicates using an equals sign to join an argument with its value. I have noticed that some arguments noticeably do not work without the equals sign
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->
This adds a sorely lacking command line argument for the installer: the ability to control the installation context (system-wide vs user-only).

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
This has been tested locally, by pulling and installing from a Nexus Repository Manager nuget repo which I use with chocolatey.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).