### PR TITLE
libreoffice-still fix 404 errors

### DIFF
--- a/automatic/libreoffice-streams/tools/chocolateyInstall.ps1
+++ b/automatic/libreoffice-streams/tools/chocolateyInstall.ps1
@@ -1,16 +1,32 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+Import-Module $PSScriptRoot\utils\archive-helper.psm1
+
 $packageArgs = @{
   packageName            = 'libreoffice'
   fileType               = 'msi'
-  url                    = 'https://download.documentfoundation.org/libreoffice/stable/6.2.5/win/x86/LibreOffice_6.2.5_Win_x86.msi'
-  url64bit               = 'https://download.documentfoundation.org/libreoffice/stable/6.2.5/win/x86_64/LibreOffice_6.2.5_Win_x64.msi'
-  checksum               = '717fb9e17a3feb8af1662e668b919db86fab343303b78f88c7859003056ee010'
-  checksum64             = '9b01f6f382dbb31367e12cfb0ad4c684546f00edb20054eeac121e7e036a5389'
+  url                    = 'https://download.documentfoundation.org/libreoffice/stable/6.0.7/win/x86/LibreOffice_6.0.7_Win_x86.msi'
+  url64bit               = 'https://download.documentfoundation.org/libreoffice/stable/6.0.7/win/x86_64/LibreOffice_6.0.7_Win_x64.msi'
+  checksum               = 'b9ffc938b4f1305676cfaa6b7a6db205e39eb82abccd540ec1e84ca7def6a50d'
+  checksum64             = '851794df64168af694edd182af019a7579744945c22465f13599efd65d730cb2'
   checksumType           = 'sha256'
   checksumType64         = 'sha256'
   silentArgs             = '/passive /norestart /l*v "{0}\install.log"' -f "$Env:TEMP\chocolatey\$Env:ChocolateyPackageName\$Env:ChocolateyPackageVersion"
   validExitCodes         = @(0,3010)
   softwareName           = 'LibreOffice*'
 }
-Install-ChocolateyPackage @packageArgs
+
+if ((Get-URLStatus $packageArgs.url) -eq $true){
+    #Install-ChocolateyPackage @packageArgs
+    Write-Output "use default settings"
+
+} else {
+    $archiveURL = Get-ArchiveURL -softwareVersion "6.0.7" -softwareHash32 $packageArgs.checksum -softwareHash64 $packageArgs.checksum64
+    
+    $packageArgs.url = $archiveURL[0]
+    $packageArgs.url64bit = $archiveURL[1]
+
+    Write-Host "downloading archived version"
+    
+    #Install-ChocolateyPackage @packageArgs
+}

--- a/automatic/libreoffice-streams/tools/utils/archive-helper.psm1
+++ b/automatic/libreoffice-streams/tools/utils/archive-helper.psm1
@@ -1,0 +1,106 @@
+<#
+ .Synopsis
+  Checks if the URL provided is available or not.
+
+ .Description
+  Checks if the URL provided is available or not. Return 'True' if URL is available
+  and 'False' if not.
+
+ .Parameter url
+  Provide the URL as String.
+
+ .Example
+   # Check if URL is available.
+   Get-URLStatus "https://www.google.de"
+#>
+
+function Get-URLStatus{
+    [CmdletBinding()]
+    Param(
+    [Parameter(ValueFromPipeline)]
+    [String]$url
+    )
+    
+    try {
+        [net.httpWebRequest] $req = [net.webRequest]::create($url)
+        $req.Method = "HEAD"
+        [net.httpWebResponse] $res = $req.getResponse()
+
+        if ($res.StatusCode -eq "200") {
+            # version is not archived yet
+            Return $true
+            continue
+        }
+        } catch {
+            # version got archived
+            Return $false
+            continue
+        }
+}
+
+Export-ModuleMember -Function Get-URLStatus
+
+<#
+ .Synopsis
+  Returns the SHA256 matching URL of the LibreOffice software.
+
+ .Description
+  This function returns the archive URLs of the LibreOffice software based
+  on the provided Version (like 6.0.7) and SHA256 values.
+
+ .Parameter softwareVersion
+  The software version, like 6.0.7.
+
+ .Parameter softwareHash32
+  The SHA256 hash of the 32bit installer file.
+
+ .Parameter softwareHash64
+  The SHA256 hash of the 64bit installer file.
+
+ .Example
+  Get-ArchiveURL -softwareVersion "6.0.7" -softwareHash32 "abcd" -softwareHash64 "def"
+#>
+
+function Get-ArchiveURL{
+    [CmdletBinding()]
+    Param(
+    [Parameter(ValueFromPipeline)]
+    [String]$softwareVersion,
+    [String]$softwareHash64,
+    [String]$softwareHash32
+    )
+    
+    $archiveURL = Invoke-WebRequest http://downloadarchive.documentfoundation.org/libreoffice/old/ -UseBasicParsing  
+    $versions = $archiveURL.Links |?{$_.href -match $softwareVersion} 
+
+    ForEach ($version in $versions.href){
+        $version = $version.Replace("/","")
+        # Download mirrorlist, search for the sha256 string
+
+        $mirrorListURL64 = "http://downloadarchive.documentfoundation.org/libreoffice/old/${version}/win/x86_64/LibreOffice_${version}_Win_x64.msi.mirrorlist"
+        $mirrorListURL32 = "http://downloadarchive.documentfoundation.org/libreoffice/old/${version}/win/x86/LibreOffice_${version}_Win_x86.msi.mirrorlist"
+        $tmpFile64 = $env:TEMP+"\libreoffice_64_${version}_mirrorlist.txt"
+        $tmpFile32 = $env:TEMP+"\libreoffice_32_${version}_mirrorlist.txt"
+
+        (New-Object System.Net.WebClient).DownloadFile($mirrorListURL64, $tmpFile64)
+        (New-Object System.Net.WebClient).DownloadFile($mirrorListURL32, $tmpFile32)
+
+        if (((Get-Content $tmpFile64 | Where { $_.Contains($softwareHash64) }) -match $softwareHash64) -and ((Get-Content $tmpFile32 | Where { $_.Contains($softwareHash32) }) -match $softwareHash32)) {
+            # version number matches, set download path for 64 bit           
+			$returnURLs = @()
+			$returnURLs += ( $downloadURL32 = $mirrorListURL32.Replace(".mirrorlist","") )
+			$returnURLs += ( $downloadURL64 = $mirrorListURL64.Replace(".mirrorlist","") )
+			
+            Return $returnURLs
+
+            Remove-Item -Path $env:TEMP\libreoffice*.txt
+            continue
+        } else { 
+            Write-Debug "$version does not match bit hash"
+            Remove-Item -Path $env:TEMP\libreoffice*.txt
+            continue
+        }
+    }
+}
+
+Export-ModuleMember -Function Get-ArchiveURL


### PR DESCRIPTION
## Description
I've created two powershell functions to show a available download link to the 32bit and 64bit installer for the LibreOffice verstion based on a given hash value.

## Motivation and Context
If a newer version of - for example - LibreOffice Still - is published, the previous version (say 6.0.7) is moved to the archive. But not as a simple downloadable link, rather then there are some more versions generated (for example 6.0.7.1, 6.0.7.2, 6.0.7.3). 

On the initial release of the choco package, the given SHA256 value is the same as the archived 6.0.7.3 version. To determine which archived version is a SHA256-matching one i've created the powershell function "Get-ArchiveURL". It needs a Version string and two Hash-Strings. Based on the hash string and the version the matching archive URL is being provided.

I've modified the chocolateyInstall-script in a way that, if the current version has not been archived yet, the packageArgs will be used unaltered.
But if the version has been archived, only the URL parameters of the packageArgs are modified, since based on the SHA256 value the software is the same.

This not only works with libreoffice-still but also with libreoffice-fresh. This package basically provides always either the official current release download link or the archived one.

## How Has this Been Tested?
I've tested this with a legacy version (6.0.7) and a current release (6.2.5).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).

## Original Location
- Original Repository: https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/libreoffice-streams
- Open Issues:
 - i'm surprised that no issue is opened for this yet.