### PR TITLE
(clipgrab) Fixed /automatic/clipgrab/update.ps1 to remove AdWare

### DIFF
--- a/automatic/clipgrab/update.ps1
+++ b/automatic/clipgrab/update.ps1
@@ -21,7 +21,7 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
   $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-  $re = 'cgorg\.exe$'
+  $re = 'portable\.exe$'
   $url = $download_page.Links | ? href -match $re | select -first 1 -expand href
 
   $verRe = '[-]|\.exe$'


### PR DESCRIPTION
Fixed /automatic/clipgrab/update.ps1 to remove AdWare.
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->
The default ClipGrab executable (cgorg.exe) has third-party offers in it. This fix will use a clean version without third-party offers.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->
By using a clean version, the user won't have to uninstall any adware that may be installed using the default version. Issue #1309 

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
This will only change the end of the file, tested and it works.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).