### PR TITLE
(chocolatey-vscode.extension) Add support for insider builds and user level installers

### DIFF
--- a/extensions/chocolatey-vscode.extension/CHANGELOG.md
+++ b/extensions/chocolatey-vscode.extension/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 1.1.0
 
-- `Install-VsCodeExtension` supports now also Insider builds and user level installer
-- `Uninstall-VsCodeExtension` supports now also Insider builds and user level installer
+- `Install-VsCodeExtension` and `Uninstall-VsCodeExtension` support now also Insider builds and user level installer
+- `Install-VsCodeExtension` and `Uninstall-VsCodeExtension` no longer require elevated permissions
 
 ## 1.0.0
 

--- a/extensions/chocolatey-vscode.extension/CHANGELOG.md
+++ b/extensions/chocolatey-vscode.extension/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
-## 1.0
+## 1.1.0
+
+- `Install-VsCodeExtension` supports now also Insider builds and user level installer
+- `Uninstall-VsCodeExtension` supports now also Insider builds and user level installer
+
+## 1.0.0
 
 - Added `Install-VsCodeExtension`
 - Added `Uninstall-VsCodeExtension`

--- a/extensions/chocolatey-vscode.extension/chocolatey-vscode.extension.nuspec
+++ b/extensions/chocolatey-vscode.extension/chocolatey-vscode.extension.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>chocolatey-vscode.extension</id>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <title>Chocolatey Visual Studio Code servicing extension</title>
     <summary>Helper functions useful for developing packages for installing Visual Studio Code extensions.</summary>
     <authors>chocolatey</authors>

--- a/extensions/chocolatey-vscode.extension/extensions/Install-VsCodeExtension.ps1
+++ b/extensions/chocolatey-vscode.extension/extensions/Install-VsCodeExtension.ps1
@@ -50,7 +50,7 @@ function Install-VsCodeExtension {
         Write-Verbose "Visual Studio Code installation found at $installLocation"
     
         Write-Host "Installing Visual Studio Code extension $extensionId in $installLocation..."
-        Start-ChocolateyProcessAsAdmin -ExeToRun $installLocation -Statements "--install-extension",$extensionId    
+        Start-ChocolateyProcessAsAdmin -ExeToRun $installLocation -Statements "--install-extension",$extensionId -Elevated:$false
     }
 
     Write-Verbose "Locating Visual Studio Code system level installation directory..."

--- a/extensions/chocolatey-vscode.extension/extensions/Uninstall-VsCodeExtension.ps1
+++ b/extensions/chocolatey-vscode.extension/extensions/Uninstall-VsCodeExtension.ps1
@@ -5,6 +5,10 @@
 .DESCRIPTION
     Uninstalls an extension from Visual Studio Code.
 
+    Supports regular and Insider builds of Visual Studio Code.
+    Supports also system and user level installations of Visual Studio Code.
+    If multiple installations are found the extension is uninstalled from all installations. 
+
     Use -Verbose parameter to see which location of Visual Studio Code is used.
 
 .EXAMPLE
@@ -20,16 +24,36 @@ function Uninstall-VsCodeExtension {
         [string]$extensionId
     )
 
-    Write-Verbose "Locating Visual Studio Code installation directory..."
-    $codePath = Get-AppInstallLocation "Microsoft Visual Studio Code" | Where-Object { Test-Path "$_\bin\code.cmd" } | Select-Object -first 1 | ForEach-Object { "$_\bin\code.cmd" }
-   
-    if (!$codePath) {
-      Write-Error "Visual Studio Code installation directory was not found."
-      throw "Visual Studio Code installation directory was not found."
+    function UninstallExtension($installLocation, $executablePath) {
+        if (!$installLocation) {
+            return
+        }
+
+        Write-Verbose "Visual Studio Code installation found at $installLocation"
+    
+        Write-Host "Uninstalling Visual Studio Code extension $extensionId from $installLocation..."
+        Start-ChocolateyProcessAsAdmin -ExeToRun $installLocation -Statements "--uninstall-extension",$extensionId    
     }
 
-    Write-Verbose "Visual Studio Code installation found at $codePath"
+    Write-Verbose "Locating Visual Studio Code system level installation directory..."
+    $installLocationSystemLevel = Get-AppInstallLocation "Microsoft Visual Studio Code" | Where-Object { Test-Path "$_\bin\code.cmd" } | Select-Object -first 1 | ForEach-Object { "$_\bin\code.cmd" }
 
-    Write-Host "Uninstalling Visual Studio Code extension $extensionId..."
-    Start-ChocolateyProcessAsAdmin -ExeToRun $codePath -Statements "--uninstall-extension",$extensionId
+    Write-Verbose "Locating Visual Studio Code user level installation directory..."
+    $installLocationUserLevel = Get-AppInstallLocation "Microsoft Visual Studio Code (User)" | Where-Object { Test-Path "$_\bin\code.cmd" } | Select-Object -first 1 | ForEach-Object { "$_\bin\code.cmd" }
+
+    Write-Verbose "Locating Visual Studio Code Insiders build system level installation directory..."
+    $installLocationInsidersSystemLevel = Get-AppInstallLocation "Microsoft Visual Studio Code Insiders" | Where-Object { Test-Path "$_\bin\code-insiders.cmd" } | Select-Object -first 1 | ForEach-Object { "$_\bin\code-insiders.cmd" }
+
+    Write-Verbose "Locating Visual Studio Code Insiders build user level installation directory..."
+    $installLocationInsidersUserLevel = Get-AppInstallLocation "Microsoft Visual Studio Code Insiders (User)" | Where-Object { Test-Path "$_\bin\code-insiders.cmd" } | Select-Object -first 1 | ForEach-Object { "$_\bin\code-insiders.cmd" }
+
+    if (!$installLocationSystemLevel -and !$installLocationUserLevel -and !$installLocationInsidersSystemLevel -and !$installLocationInsidersUserLevel) {
+        Write-Error "Visual Studio Code installation directory was not found."
+        throw "Visual Studio Code installation directory was not found."
+    }
+
+    UninstallExtension $installLocationSystemLevel $extensionId
+    UninstallExtension $installLocationUserLevel $extensionId
+    UninstallExtension $installLocationInsidersSystemLevel $extensionId
+    UninstallExtension $installLocationInsidersUserLevel $extensionId
 }

--- a/extensions/chocolatey-vscode.extension/extensions/Uninstall-VsCodeExtension.ps1
+++ b/extensions/chocolatey-vscode.extension/extensions/Uninstall-VsCodeExtension.ps1
@@ -32,7 +32,7 @@ function Uninstall-VsCodeExtension {
         Write-Verbose "Visual Studio Code installation found at $installLocation"
     
         Write-Host "Uninstalling Visual Studio Code extension $extensionId from $installLocation..."
-        Start-ChocolateyProcessAsAdmin -ExeToRun $installLocation -Statements "--uninstall-extension",$extensionId    
+        Start-ChocolateyProcessAsAdmin -ExeToRun $installLocation -Statements "--uninstall-extension",$extensionId -Elevated:$false
     }
 
     Write-Verbose "Locating Visual Studio Code system level installation directory..."


### PR DESCRIPTION
## Description
Add support for installing extensions in insider builds and user level installations of Visual Studio Code.

## Motivation and Context
There were user requests for supporting Insider builds for the Chocolatey extensions:

- https://github.com/pascalberger/chocolatey-packages/issues/115
- https://chocolatey.org/packages/vscode-docker#comment-4561079523

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
Tested locally with different combinations of Visual Studio Code installations.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
