### PR TITLE
docs(gnupg): Fix package link in README.md

### DIFF
--- a/automatic/gnupg/README.md
+++ b/automatic/gnupg/README.md
@@ -1,4 +1,4 @@
-# <img src="https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@901944b6fe60360ef2764c9fc53fe69dee99abd5/icons/gnupg.png" width="48" height="48"/> [gnupg](https://chocolatey.org/packages/gnupg-modern)
+# <img src="https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@901944b6fe60360ef2764c9fc53fe69dee99abd5/icons/gnupg.png" width="48" height="48"/> [gnupg](https://chocolatey.org/packages/gnupg)
 
 GnuPG itself is a commandline tool without any graphical stuff. It is the real crypto engine which can be used directly from a command prompt, from shell scripts or by other programs. Therefore it can be considered as a backend for other applications.
 


### PR DESCRIPTION
## Description
This corrects the package link in the `README.md` heading to point to: [https://chocolatey.org⁠/packages⁠/gnupg](https://chocolatey.org/packages/gnupg).

This doesn’t require a new publish, as the first heading is not included in the description.

## Motivation and Context
The current link points to the old package ID ([gnupg‑modern](https://chocolatey.org/packages/gnupg-modern)).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
