### PR TITLE
(curl) fix incorrect version being grabbed

### DIFF
--- a/automatic/curl/update.ps1
+++ b/automatic/curl/update.ps1
@@ -35,7 +35,7 @@ function global:au_GetLatest {
     @{
         Version      = $version
         URL32        = $url -match 'win32' | select -first 1
-        URL64        = $url | { $_ -notmatch 'win32' -and $_ -match $version } | select -first 1
+        URL64        = $url | ? { $_ -notmatch 'win32' -and $_ -match $version } | select -first 1
         ReleaseNotes = $releaseNotes
     }
 }

--- a/automatic/curl/update.ps1
+++ b/automatic/curl/update.ps1
@@ -35,7 +35,7 @@ function global:au_GetLatest {
     @{
         Version      = $version
         URL32        = $url -match 'win32' | select -first 1
-        URL64        = $url { $_ -notmatch 'win32' -and $_ -match $version } | select -first 1
+        URL64        = $url | { $_ -notmatch 'win32' -and $_ -match $version } | select -first 1
         ReleaseNotes = $releaseNotes
     }
 }

--- a/automatic/curl/update.ps1
+++ b/automatic/curl/update.ps1
@@ -35,7 +35,7 @@ function global:au_GetLatest {
     @{
         Version      = $version
         URL32        = $url -match 'win32' | select -first 1
-        URL64        = $url -notmatch 'win32' | select -first 1
+        URL64        = $url { $_ -notmatch 'win32' -and $_ -match $version } | select -first 1
         ReleaseNotes = $releaseNotes
     }
 }


### PR DESCRIPTION
Due to not having the control of the order of the urls grabbed from
the website, we are sometimes grabbing the wrong version of the
64bit installer compared to the version we got for the 32bit installer.
This commit fixes that issue.

Reported on: http://disq.us/p/24kj4gl