### PR TITLE
(inkscape) Add shim to inkscape.exe (#1344)

### DIFF
--- a/automatic/inkscape/tools/chocolateyInstall.ps1
+++ b/automatic/inkscape/tools/chocolateyInstall.ps1
@@ -42,6 +42,7 @@ Get-ChildItem $toolsPath\*.msi | ForEach-Object { Remove-Item $_ -ea 0; if (Test
 $packageName = $packageArgs.packageName
 $installLocation = Get-AppInstallLocation $packageArgs['softwareName']
 if ($installLocation) {
+  Install-BinFile 'inkscape' $installLocation\inkscape.exe
   Write-Host "$packageName installed to '$installLocation'"
 }
 else { Write-Warning "Can't find $PackageName install location" }

--- a/automatic/inkscape/tools/chocolateyUninstall.ps1
+++ b/automatic/inkscape/tools/chocolateyUninstall.ps1
@@ -1,0 +1,1 @@
+﻿Uninstall-BinFile 'inkscape'


### PR DESCRIPTION
This will add a shim for inkscape.exe to allow people to use inkscape directly from the terminal.

## Description
This pull request added a new `Install-BinFile` in `automatic/inkscape/tools/chocolateyInstall.ps1` which will allow Inkscape to be launched or to execute commands (https://inkscape.org/de/doc/inkscape-man.html) directly from the terminal. 

Also included in this commit is the `Uninstall-BinFile` located in the newly made `chocolateyUninstall.ps1`, which ensures that the shim is removed when uninstalling inkscape.

I was unable to test this in the Chocolatey Test Environment, but since this is a rather small addition it shouldn't break any stuff.

## Motivation and Context
This is especially useful for people who need to modify/change vector graphics without a GUI or to convert from AI (Illustrator file format) to SVG.

This also fixes https://github.com/chocolatey-community/chocolatey-coreteampackages/issues/1344.

## How Has this Been Tested?
This has been tested by manually placing the MSI files in the `tools` folder, then creating the package with `choco pack`. After that i've installed the package with `choco install inkscape -dv -s .` and checked if the shim works with `inkscape`. As a last step i've uninstalled the package via `choco uninstall inkscape` and rechecked if `inkscape` is no longer working.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
