### PR TITLE
(virtualbox) Uninstall no longer fails when there are no extensions installed

### DIFF
--- a/automatic/virtualbox/tools/chocolateyUninstall.ps1
+++ b/automatic/virtualbox/tools/chocolateyUninstall.ps1
@@ -14,11 +14,14 @@ $vboxManage = "$installLocation\VBoxManage.exe"
 if (!(Test-Path $vboxManage)) { Write-Warning "Existing installation of $packageName found but unable to find VBoxManage.exe"; return }
 
 $extensions = . $vboxManage list extpacks | Where-Object { $_ -match 'Pack no' } | ForEach-Object { $_ -split '\:' | Select-Object -last 1 }
-$extensions | ForEach-Object {
-  $extName = $_.Trim()
-  Write-Host "Uninstalling extension: '$extName'"
-  Start-ChocolateyProcessAsAdmin -ExeToRun $vboxManage -Statements 'extpack','uninstall',"`"$extName`"" -Elevate 2>&1
-}
 
-Write-Host "Cleaning up extensions before uninstalling virtualbox"
-Start-ChocolateyProcessAsAdmin -ExeToRun $vboxManage -Statements 'extpack', 'cleanup' 2>&1
+if ($extensions) {
+  $extensions | ForEach-Object {
+    $extName = $_.Trim()
+    Write-Host "Uninstalling extension: '$extName'"
+    Start-ChocolateyProcessAsAdmin -ExeToRun $vboxManage -Statements 'extpack','uninstall',"`"$extName`"" -Elevate 2>&1
+  }
+
+  Write-Host "Cleaning up extensions before uninstalling virtualbox"
+  Start-ChocolateyProcessAsAdmin -ExeToRun $vboxManage -Statements 'extpack', 'cleanup' 2>&1
+}


### PR DESCRIPTION
# Description
Fixes #1353

## Motivation and Context
Package's uninstallation process was failing when there were no extensions installed.

## How Has this Been Tested?
I tested the updated package in chocolatey test environment.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
