### PR TITLE
(vagrant) Update plugins after software update

### DIFF
--- a/automatic/vagrant/tools/chocolateyinstall.ps1
+++ b/automatic/vagrant/tools/chocolateyinstall.ps1
@@ -1,4 +1,6 @@
-﻿$ErrorActionPreference = 'Stop'
+Import-Module "$PSScriptRoot\..\..\..\extensions\chocolatey-core.extension\extensions\Get-EffectiveProxy.ps1"
+
+$ErrorActionPreference = 'Stop'
 
 $packageArgs = @{
   packageName    = 'vagrant'

--- a/automatic/vagrant/tools/chocolateyinstall.ps1
+++ b/automatic/vagrant/tools/chocolateyinstall.ps1
@@ -1,5 +1,3 @@
-Import-Module "$PSScriptRoot\..\..\extensions\chocolatey-core.extension\extensions\Get-EffectiveProxy.ps1"
-
 $ErrorActionPreference = 'Stop'
 
 $packageArgs = @{

--- a/automatic/vagrant/tools/chocolateyinstall.ps1
+++ b/automatic/vagrant/tools/chocolateyinstall.ps1
@@ -18,6 +18,7 @@ Install-ChocolateyPackage @packageArgs
 Update-SessionEnvironment
 
 $ErrorActionPreference = 'Continue' #https://github.com/chocolatey/chocolatey-coreteampackages/issues/1099
+vagrant plugin update               #https://github.com/chocolatey/chocolatey-coreteampackages/issues/1358
 vagrant plugin repair               #https://github.com/chocolatey/chocolatey-coreteampackages/issues/1024
 if ($LastExitCode -ne 0) {          #https://github.com/chocolatey/chocolatey-coreteampackages/issues/1099
   Write-Host "WARNING: Plugin repair failed, run 'vagrant plugin expunge --reinstall' after rebooting."

--- a/automatic/vagrant/tools/chocolateyinstall.ps1
+++ b/automatic/vagrant/tools/chocolateyinstall.ps1
@@ -18,7 +18,15 @@ Install-ChocolateyPackage @packageArgs
 Update-SessionEnvironment
 
 $ErrorActionPreference = 'Continue' #https://github.com/chocolatey/chocolatey-coreteampackages/issues/1099
-vagrant plugin update               #https://github.com/chocolatey/chocolatey-coreteampackages/issues/1358
+
+#https://github.com/chocolatey/chocolatey-coreteampackages/issues/1358
+$proxy = Get-EffectiveProxy
+if ($proxy) {
+  Write-Host "Setting CLI proxy: $proxy"
+  $env:http_proxy = $env:https_proxy = $proxy
+}
+vagrant plugin update
+
 vagrant plugin repair               #https://github.com/chocolatey/chocolatey-coreteampackages/issues/1024
 if ($LastExitCode -ne 0) {          #https://github.com/chocolatey/chocolatey-coreteampackages/issues/1099
   Write-Host "WARNING: Plugin repair failed, run 'vagrant plugin expunge --reinstall' after rebooting."

--- a/automatic/vagrant/tools/chocolateyinstall.ps1
+++ b/automatic/vagrant/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-Import-Module "$PSScriptRoot\..\..\..\extensions\chocolatey-core.extension\extensions\Get-EffectiveProxy.ps1"
+Import-Module "$PSScriptRoot\..\..\extensions\chocolatey-core.extension\extensions\Get-EffectiveProxy.ps1"
 
 $ErrorActionPreference = 'Stop'
 

--- a/automatic/vagrant/vagrant.nuspec
+++ b/automatic/vagrant/vagrant.nuspec
@@ -27,6 +27,9 @@ To achieve its magic, Vagrant stands on the shoulders of giants. Machines are pr
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@269d34200380fe4fded0508b85e341e1c055cd85/icons/vagrant.png</iconUrl>
     <releaseNotes>[CHANGELOG](https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md)</releaseNotes>
     <!--<provides>vagrant</provides>-->
+    <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.3.3" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
Some plugins like vagrant-vbguest needs an update to be compatible with the new Vagrant version.

## Description

Just added `vagrant plugin update` as post task to the Vagrant update.

## Motivation and Context

https://github.com/chocolatey/chocolatey-coreteampackages/issues/1358

## How Has this Been Tested?

Manually tested.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

## Original Location
- [Open Issues](https://github.com/chocolatey/chocolatey-coreteampackages/issues/1358)
