### PR TITLE
Sanitize URL properly to allow download with Posh .NET WebClient

### DIFF
--- a/automatic/mattermost-desktop/update.ps1
+++ b/automatic/mattermost-desktop/update.ps1
@@ -32,18 +32,18 @@ function global:au_GetLatest {
     # Sanitize string by spliting on spaces, and taking the longest
     # Example of unnsanitized string
     # > - https://releases.mattermost.com/desktop/4.3.0/mattermost-desktop-v4.3.0-x64.msi (beta)
-    $msiUrl = ([string]$_).Split("`n")[0].Split(' ').where{$_.length -gt 10 }
+    $msiUrl = ([string]$_).Split("`n")[0].Split(' ').where{ $_.length -gt 10 }.trim()
     ([string]$_).Split("`n")[1] -match '.*`(?<hash>.*)`.*' | Out-Null
     $digest = $matches['hash']
 
     if ($msiUrl -like '*x64*') {
-      $msiUrl64 = [string]$msiUrl
+      $msiUrl64 = $msiUrl
       $msiFilename64 = Split-Path -leaf $msiUrl
       $digest64 = $digest
     } else {
-      $msiUrl32 = [string]$msiUrl
-      $digest32 = $digest
+      $msiUrl32 = $msiUrl
       $msiFilename32 = Split-Path -leaf $msiUrl
+      $digest32 = $digest
     }
   }
 


### PR DESCRIPTION
## Description
Mattermost URL parsing was not sanitized enough leading in Posh .NET WebClient to complain with a `Illegal characters in path.` exception.

## Motivation and Context
See above

## How Has this Been Tested?
Tested locally with AU

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
