### PR TITLE
(freecad) manual update

### DIFF
--- a/automatic/freecad/freecad.nuspec
+++ b/automatic/freecad/freecad.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>freecad</id>
-    <version>0.18.16131</version>
+    <version>0.18.16146</version>
     <title>FreeCAD</title>
     <owners>chocolatey,purity</owners>
     <authors>Jürgen Riegel</authors>

--- a/automatic/freecad/tools/chocolateyInstall.ps1
+++ b/automatic/freecad/tools/chocolateyInstall.ps1
@@ -3,12 +3,12 @@
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   fileType       = 'exe'
-  url            = 'https://github.com/FreeCAD/FreeCAD/releases/download/0.18.3/FreeCAD-0.18.16131.3129ae4-WIN-x32-installer.exe'
-  url64          = 'https://github.com/FreeCAD/FreeCAD/releases/download/0.18.3/FreeCAD-0.18.16131.3129ae4-WIN-x64-installer.exe'
+  url            = 'https://github.com/FreeCAD/FreeCAD/releases/download/0.18.4/FreeCAD-0.18.4.980bf90-WIN-x32-installer.exe'
+  url64          = 'https://github.com/FreeCAD/FreeCAD/releases/download/0.18.4/FreeCAD-0.18.4.980bf90-WIN-x64-installer.exe'
   softwareName   = 'FreeCAD*'
-  checksum       = 'ef5d4108329c71b4b5b60fbe2fbc49acef86694942e83765a4863010eabe0d79'
+  checksum       = 'a3c00e00e5321d9786c56d58c501f8a8e43ba9d25f7147cd8b9c869d744be514'
   checksumType   = 'sha256'
-  checksum64     = 'c521b8ca5dd9ed287bc3afbe57aa39f4dea4ca89e13fb58c3258d3792f86d48f'
+  checksum64     = 'd70930110929117c3a198d3c815a9169e383ab88f650431a1a1ece7705d2ef1b'
   checksumType64 = 'sha256'
   silentArgs     = '/S'
   validExitCodes = @(0)


### PR DESCRIPTION
## Description
Manual update, automatic update will work again when a version like "0.19.x" will be released.
Until now, the published version is a mix between the major version and build number so to have again a conventional versioning with the update script, it needs to manually update this package until a version greater or equal to 0.19 is released by Freecad.

```
RemoteVersion : 0.18.4
NuspecVersion : 0.18.16131
```

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Manual update of Freecad. New version has been released 8 days ago and the current update script can't update Freecad until a version greater or equal to 0.19 is released.
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
