### PR TITLE
[AU qbittorrent:4.1.9.1] Force update “qBittorrent” to v4.1.9.1

### DIFF
--- a/automatic/qbittorrent/qbittorrent.nuspec
+++ b/automatic/qbittorrent/qbittorrent.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>qbittorrent</id>
     <title>qBittorrent</title>
-    <version>4.1.9</version>
+    <version>4.1.9.1</version>
     <authors>Christophe Dumez</authors>
     <owners>chocolatey,nconrads</owners>
     <summary>qBittorrent is a free software cross-platform BitTorrent client GUI written with Qt4.</summary>

--- a/automatic/qbittorrent/tools/VERIFICATION.txt
+++ b/automatic/qbittorrent/tools/VERIFICATION.txt
@@ -6,14 +6,14 @@ The installer have been downloaded from the alternative sourceforge mirror liste
 and can be verified like this:
 
 1. Download the following installers:
-  32-Bit: <https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.1.9/qbittorrent_4.1.9_setup.exe/download>
-  64-Bit: <https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.1.9/qbittorrent_4.1.9_x64_setup.exe/download>
+  32-Bit: <https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.1.9.1/qbittorrent_4.1.9.1_setup.exe/download>
+  64-Bit: <https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.1.9.1/qbittorrent_4.1.9.1_x64_setup.exe/download>
 2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: sha256
-  checksum32: 4505ABA7CDEACA89C4C549E45F3CF631D4D553B08CAF5B769F20D6F2601D33B3
-  checksum64: 8D5473FC1496B1C37DB56BE6FD4D05AF6E1833CB578482BCA63F75A9C807178E
+  checksum32: F52A059C478ECB1D7829F6C560D8D932F540A1577481B8649EF13CB8CA427FBE
+  checksum64: B981598F9E4D43630B65C17A9FAC7A1C1EBE5211A51B3699C7AFDA1CF04A13B2
 
 File 'LICENSE.txt' is obtained from <https://github.com/qbittorrent/qBittorrent/blob/0070dcf5509e43c2c3457c4e3f1ed0b1ae087e36/COPYING>

--- a/automatic/qbittorrent/tools/chocolateyinstall.ps1
+++ b/automatic/qbittorrent/tools/chocolateyinstall.ps1
@@ -6,8 +6,8 @@ $packageArgs = @{
   packageName    = 'qbittorrent'
   fileType       = 'exe'
   softwareName   = 'qBittorrent*'
-  file           = "$toolsDir\qbittorrent_4.1.9_setup.exe"
-  file64         = "$toolsDir\qbittorrent_4.1.9_x64_setup.exe"
+  file           = "$toolsDir\qbittorrent_4.1.9.1_setup.exe"
+  file64         = "$toolsDir\qbittorrent_4.1.9.1_x64_setup.exe"
   silentArgs     = '/S'
   validExitCodes = @(0, 1223)
 }


### PR DESCRIPTION
## Description
This attempts to forcefully update “**qBittorrent**” to v4.1.9.1

## Motivation and Context
This is needed because of #1376/#1217.

## How Has this Been Tested?
I’ve successfully run `./update.ps1` and `choco install ./qbittorrent.4.1.9.1.nupkg` locally from the `./automatic/qbittorrent/` directory.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
