### PR TITLE
(BeCyIconGrabber) (GH-1384) add start menu shortcut

### DIFF
--- a/manual/becyicongrabber/README.md
+++ b/manual/becyicongrabber/README.md
@@ -3,3 +3,10 @@
 
 BeCyIconGrabber is a small utility to view icons and cursors of any sizes that are contained in EXE, DLL, ICL, OCX, CPL, SRC, ICO and CUR files. The icons/cursors can be saved either individually as an icon, cursor, bitmap, png file or collectively within resource libraries.
 
+#### Package Parameters
+The following package parameters can be set:
+
+ * `/NOSTART` - Do not add a start menu item
+
+To pass parameters, use `--params "''"` (e.g. `choco install packageID [other options] --params="'/ITEM:value /ITEM2:value2 /FLAG_BOOLEAN'"`).
+To have choco remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`. 

--- a/manual/becyicongrabber/becyicongrabber.nuspec
+++ b/manual/becyicongrabber/becyicongrabber.nuspec
@@ -13,6 +13,14 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
 BeCyIconGrabber is a small utility to view icons and cursors of any sizes that are contained in EXE, DLL, ICL, OCX, CPL, SRC, ICO and CUR files. The icons/cursors can be saved either individually as an icon, cursor, bitmap, png file or collectively within resource libraries.
+
+#### Package Parameters
+The following package parameters can be set:
+
+ * `/NOSTART` - Do not add a start menu item
+
+To pass parameters, use `--params "''"` (e.g. `choco install packageID [other options] --params="'/ITEM:value /ITEM2:value2 /FLAG_BOOLEAN'"`).
+To have choco remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`. 
     </description>
     <summary>BeCyIconGrabber – extraction of icons/cursors</summary>
     <releaseNotes />

--- a/manual/becyicongrabber/tools/chocolateyInstall.ps1
+++ b/manual/becyicongrabber/tools/chocolateyInstall.ps1
@@ -1,4 +1,7 @@
 $language = (Get-Culture).Parent.Name
+$pp       = Get-PackageParameters
+$exePath  = Join-Path "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" 'BeCyIconGrabber.exe'
+$iconName = 'BeCyIconGrabber.lnk'
 
 $packageArgs = @{
   packageName = 'becyicongrabber'
@@ -14,3 +17,9 @@ if ($language -eq 'de') {
 }
 
 Install-ChocolateyZipPackage @packageArgs
+
+if (!$pp['nostart']) {
+	$startIcon = (Join-Path ([environment]::GetFolderPath([environment+specialfolder]::Programs)) $iconName)
+	Write-Host -ForegroundColor green 'Adding ' $startIcon
+	Install-ChocolateyShortcut -ShortcutFilePath $startIcon -TargetPath $exePath
+}

--- a/manual/becyicongrabber/tools/chocolateyuninstall.ps1
+++ b/manual/becyicongrabber/tools/chocolateyuninstall.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop';
+$iconName  = 'BeCyIconGrabber.lnk'
+$startIcon = (Join-Path ([environment]::GetFolderPath([environment+specialfolder]::Programs)) $iconName)
+
+if (Test-Path $starticon) {
+	Remove-Item $starticon
+	Write-Host -ForegroundColor green 'Removed ' $starticon
+} else {
+	Write-Host -ForegroundColor yellow 'Did not find ' $starticon ' to remove'
+}


### PR DESCRIPTION
## Description

This adds a start menu icon/shortcut and a package parameter to not add the icon. This nesitated documentation of the parameter, and addition of an uninstallation script to remove the icon.

The Icon is installed to the current user's start menu, not to all users start menu. This is because the current user start menu does not need administrator permissions to write to, and therefore allows the package to still be portable and installable by a non-adminitrator. 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

See #1384 

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

Tested in chocolatey test environment, both install and uninstall. 
Tested on win10 machine in a non-administrative cmd. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).