### PR TITLE
(php) Fix extension_dir configuration

### DIFF
--- a/automatic/php/tools/chocolateyInstall.ps1
+++ b/automatic/php/tools/chocolateyInstall.ps1
@@ -60,7 +60,7 @@ if (!(Test-Path $php_ini_path)) {
   Copy-Item $newInstallLocation/php.ini-production $php_ini_path
 
   Write-Host 'Configuring PHP extensions directory'
-  (Get-Content $php_ini_path) -replace '; extension_dir = "ext"', 'extension_dir = "ext"' | Set-Content $php_ini_path
+  (Get-Content $php_ini_path) -replace ';\s?extension_dir = "ext"', 'extension_dir = "ext"' | Set-Content $php_ini_path
 }
 
 if (!$pp.ThreadSafe) { Write-Host 'Please make sure you have CGI installed in IIS for local hosting' }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
The extension_dir value in the default php.ini files has changed from
`; extension_dir = "ext"` to `;extension_dir = "ext"`. The replace regex
now matches both formats.

## Motivation and Context
The current method does not actually configure the `extension_dir` value in PHP 7.3.0 upwards

## How Has this Been Tested?
Tested locally in au

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

