### PR TITLE
Merge pull request #1417 [AU vagrant:2.2.7]

### DIFF
--- a/automatic/vagrant/vagrant.nuspec
+++ b/automatic/vagrant/vagrant.nuspec
@@ -17,7 +17,7 @@ To achieve its magic, Vagrant stands on the shoulders of giants. Machines are pr
     <projectUrl>https://www.vagrantup.com</projectUrl>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/vagrant</packageSourceUrl>
     <projectSourceUrl>https://github.com/mitchellh/vagrant</projectSourceUrl>
-    <docsUrl>https://docs.vagrantup.com/docs</docsUrl>
+    <docsUrl>https://www.vagrantup.com/docs/</docsUrl>
     <mailingListUrl>https://groups.google.com/forum/#!forum/vagrant-up</mailingListUrl>
     <bugTrackerUrl>https://github.com/mitchellh/vagrant/issues</bugTrackerUrl>
     <tags>vagrant admin sandbox virtual machine testing VM VirtualBox VMware cross-platform foss cli</tags>


### PR DESCRIPTION
Vagrant package has failed on an invalid <docs> field in the vagrant.nuspec file. This fixes that URL.

## Description
Adds a valid <docs> field in the vagrant.nuspec.

## Motivation and Context
Vagrant package failed validation.

## How Has this Been Tested?
Checked the URL exists. `choco pack` doesn't produce an error.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).