### PR TITLE
(WinSCP) Update ProjectSourceUrl

### DIFF
--- a/automatic/winscp.install/winscp.install.nuspec
+++ b/automatic/winscp.install/winscp.install.nuspec
@@ -36,7 +36,7 @@
     <releaseNotes>https://winscp.net/download/WinSCP-5.17.1-ReadMe.txt</releaseNotes>
     <copyright>© 2000 Martin Přikryl</copyright>
     <tags>scp cli ssh sftp ftp remote file client foss admin</tags>
-    <projectSourceUrl>https://sourceforge.net/p/winscp/code/</projectSourceUrl>
+    <projectSourceUrl>https://github.com/winscp/winscp</projectSourceUrl>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/winscp.install</packageSourceUrl>
     <docsUrl>https://winscp.net/docs/</docsUrl>
     <mailingListUrl>https://winscp.net/forum/index.php</mailingListUrl>

--- a/automatic/winscp.portable/winscp.portable.nuspec
+++ b/automatic/winscp.portable/winscp.portable.nuspec
@@ -36,7 +36,7 @@
     <releaseNotes>https://winscp.net/download/WinSCP-5.17.1-ReadMe.txt</releaseNotes>
     <copyright>© 2000 Martin Přikryl</copyright>
     <tags>scp cli ssh sftp ftp remote file client foss admin</tags>
-    <projectSourceUrl>https://sourceforge.net/p/winscp/code/</projectSourceUrl>
+    <projectSourceUrl>https://github.com/winscp/winscp</projectSourceUrl>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/winscp.portable</packageSourceUrl>
     <docsUrl>https://winscp.net/docs/</docsUrl>
     <mailingListUrl>https://winscp.net/forum/index.php</mailingListUrl>

--- a/automatic/winscp/winscp.nuspec
+++ b/automatic/winscp/winscp.nuspec
@@ -36,7 +36,7 @@
     <releaseNotes>https://winscp.net/download/WinSCP-5.17.1-ReadMe.txt</releaseNotes>
     <copyright>© 2000 Martin Přikryl</copyright>
     <tags>scp cli ssh sftp ftp remote file client foss admin</tags>
-    <projectSourceUrl>https://sourceforge.net/p/winscp/code/</projectSourceUrl>
+    <projectSourceUrl>https://github.com/winscp/winscp</projectSourceUrl>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/winscp</packageSourceUrl>
     <docsUrl>https://winscp.net/docs/</docsUrl>
     <mailingListUrl>https://winscp.net/forum/index.php</mailingListUrl>


### PR DESCRIPTION
## Description
The ProjectUrl was referring to SourceForge, but the page no longer exists. The source code is now on GitHub.

## Motivation and Context
WinSCP 5.17.1 is held in moderation because the ProjectUrl is invalid. This change should resolve that issue.

## How Has this Been Tested?
The URL is valid and is the location of WinSCP source.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
