### PR TITLE
(brave) fix the '-2147219198' error

### DIFF
--- a/automatic/brave/tools/chocolateyInstall.ps1
+++ b/automatic/brave/tools/chocolateyInstall.ps1
@@ -1,11 +1,16 @@
-﻿$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+﻿$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+. $toolsPath\helpers.ps1
 
 $packageArgs = @{
   packageName = $env:ChocolateyPackageName
-  file        = "$toolsDir\BraveBrowserStandaloneSilentSetup32.exe"
-  file64      = "$toolsDir\BraveBrowserStandaloneSilentSetup.exe"
+  file        = "$toolsPath\BraveBrowserStandaloneSilentSetup32.exe"
+  file64      = "$toolsPath\BraveBrowserStandaloneSilentSetup.exe"
 }
 
-Install-ChocolateyInstallPackage @packageArgs
+if ($alreadyInstalled -and ($env:ChocolateyForce -ne $true)) {
+  Write-Host "Skipping installation because version $alreadyInstalled is already installed."
+} else {
+  Install-ChocolateyInstallPackage @packageArgs
+}
 
-Remove-Item $toolsDir\*.exe -ea 0
+Remove-Item $toolsPath\*.exe -ea 0

--- a/automatic/brave/tools/chocolateyInstall.ps1
+++ b/automatic/brave/tools/chocolateyInstall.ps1
@@ -7,6 +7,9 @@ $packageArgs = @{
   file64      = "$toolsPath\BraveBrowserStandaloneSilentSetup.exe"
 }
 
+Write-Host "Checking already installed version..."
+CheckInstalledVersion
+
 if ($alreadyInstalled -and ($env:ChocolateyForce -ne $true)) {
   Write-Host "Skipping installation because version $alreadyInstalled is already installed."
 } else {

--- a/automatic/brave/tools/helpers.ps1
+++ b/automatic/brave/tools/helpers.ps1
@@ -1,15 +1,17 @@
-if (-not $env:ChocolateyForce) {
-  try {
-    [array]$key = Get-UninstallRegistryKey -SoftwareName 'Brave*'
-    $installedVersion = $key.Version[3..($key.Version.length - 1)]
-    $installedVersion = "$installedVersion" -replace '\s',''
+function CheckInstalledVersion() {
+  [array]$key = Get-UninstallRegistryKey -SoftwareName 'Brave*'
+  $installedVersion = $key.Version[3..($key.Version.length - 1)]
+  $installedVersion = "$installedVersion" -replace '\s',''
 
-    if ($installedVersion -ge [Version]::Parse($env:ChocolateyPackageVersion))
-    {
-      $alreadyInstalled = $installedVersion
-      return
+  if (-not $env:ChocolateyForce) {
+    try {
+      if ($installedVersion -ge [Version]::Parse($env:ChocolateyPackageVersion))
+      {
+        $global:alreadyInstalled = $installedVersion
+        return
+      }
+    } catch {
+      # Installed version couldn't be checked, attempt installation
     }
-  } catch {
-    # Installed version couldn't be checked, attempt installation
   }
 }

--- a/automatic/brave/tools/helpers.ps1
+++ b/automatic/brave/tools/helpers.ps1
@@ -1,0 +1,15 @@
+[array]$key = Get-UninstallRegistryKey -SoftwareName 'Brave*'
+$installedVersion = $key.Version[3..($key.Version.length - 1)]
+$installedVersion = "$installedVersion" -replace '\s',''
+
+if (-not $env:ChocolateyForce) {
+  try {
+    if ($installedVersion -ge [Version]::Parse($env:ChocolateyPackageVersion))
+    {
+      $alreadyInstalled = $installedVersion
+      return
+    }
+  } catch {
+    # Installed version couldn't be checked, attempt installation
+  }
+}

--- a/automatic/brave/tools/helpers.ps1
+++ b/automatic/brave/tools/helpers.ps1
@@ -1,9 +1,9 @@
-[array]$key = Get-UninstallRegistryKey -SoftwareName 'Brave*'
-$installedVersion = $key.Version[3..($key.Version.length - 1)]
-$installedVersion = "$installedVersion" -replace '\s',''
-
 if (-not $env:ChocolateyForce) {
   try {
+    [array]$key = Get-UninstallRegistryKey -SoftwareName 'Brave*'
+    $installedVersion = $key.Version[3..($key.Version.length - 1)]
+    $installedVersion = "$installedVersion" -replace '\s',''
+
     if ($installedVersion -ge [Version]::Parse($env:ChocolateyPackageVersion))
     {
       $alreadyInstalled = $installedVersion


### PR DESCRIPTION
# Description
Checking the already installed version before downloading the nuspec version.
If the already installed version is greater equal than the nuspec version, then skip installing the outdated version.

## Motivation and Context
Brave is updating automatically faster than the Chocolatey repository.
If upgrading to the outdated version, then an error occurred. (Exit code was '-2147219198')
Some reports about it are available on the package page.

## How Has this Been Tested?
Tested locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).