### PR TITLE
Fix KeeWeb license URL

### DIFF
--- a/automatic/keeweb/keeweb.nuspec
+++ b/automatic/keeweb/keeweb.nuspec
@@ -44,7 +44,7 @@ This webapp is a browser and desktop password manager compatible with KeePass da
         <projectUrl>https://keeweb.info/</projectUrl>
         <tags>keeweb keypass password admin foss cross-platform</tags>
         <copyright>2016 Antelle</copyright>
-        <licenseUrl>https://github.com/keeweb/keeweb/blob/master/LICENSE.txt</licenseUrl>
+        <licenseUrl>https://github.com/keeweb/keeweb/blob/master/LICENSE</licenseUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <!-- Source: https://github.com/keeweb/keeweb/raw/master/graphics/128x128.png -->
         <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@88bbbf93f61ceb6787fbdf191a9542dddfcb2c2c/icons/keeweb.png</iconUrl>

--- a/automatic/keeweb/legal/LICENSE.txt
+++ b/automatic/keeweb/legal/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Antelle
+Copyright (c) 2019 Antelle
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/automatic/keeweb/legal/VERIFICATION.txt
+++ b/automatic/keeweb/legal/VERIFICATION.txt
@@ -16,4 +16,4 @@ and can be verified like this:
     checksum32: 259B9CB8F5820C99206A33B3472775D656C766A8620B1969C9F05AFBC04201CD
     checksum64: 9B7F0C50D481C06C948418A493C2D54949F664D0499A958D542606C3F7960087
 
-File 'LICENSE.txt' is obtained from <https://github.com/keeweb/keeweb/blob/26d6844b65e78217d3b3eb6cfa4ed5e226404320/LICENSE>
+File 'LICENSE.txt' is obtained from <https://github.com/keeweb/keeweb/blob/01b57cf33fca8342d619120bf88ce7c680413ddc/LICENSE>


### PR DESCRIPTION
## Description
The verifier failed for KeeWeb as upstream changed the link to the LICENSE file. Now fixed.

## Motivation and Context
Fix the license file URL

## How Has this Been Tested?
Build, installed an uninstalled the package on Windows 10 and Windows 7 ESU.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

