### PR TITLE
(k9s) Remove 32bit version support

### DIFF
--- a/automatic/k9s/legal/VERIFICATION.txt
+++ b/automatic/k9s/legal/VERIFICATION.txt
@@ -6,7 +6,6 @@ in verifying that this package's contents are trustworthy.
 The embedded software can be verified by doing the following:
 
 1. Download the following:
-  32-bit software: <https://github.com/derailed/k9s/releases/download/v0.19.0/k9s_Windows_i386.tar.gz>
   64-bit software: <https://github.com/derailed/k9s/releases/download/v0.19.0/k9s_Windows_x86_64.tar.gz>
 
 2. Get the checksum using one of the following methods:
@@ -16,7 +15,6 @@ The embedded software can be verified by doing the following:
 
 3. The checksums should match the following:
   checksum type: sha256
-  checksum32: CBCA3A97332340E8183D251C37C6A89CE06B87C93A440C6580BC109407C1F09A
   checksum64: 2DA4677433CB594433850AFD1BC07D3C79AE58E95C43177AC7D428519398C427
 
 The file 'LICENSE.txt' has been obtained from <https://raw.githubusercontent.com/derailed/k9s/2e05367256a7b2777b011da7213cf636c9ae4d17/LICENSE>

--- a/automatic/k9s/tools/chocolateyinstall.ps1
+++ b/automatic/k9s/tools/chocolateyinstall.ps1
@@ -5,8 +5,7 @@ $toolsDir      = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
   PackageName    = $packageName
-  FileFullPath   = Get-Item $toolsDir\*_i386.tar.gz
-  FileFullPath64 = Get-Item $toolsDir\*_x86_64.gz
+  FileFullPath64 = Get-Item $toolsDir\k9s_Windows_x86_64.tar.gz
   Destination    = $toolsDir
 }
 
@@ -14,8 +13,7 @@ Get-ChocolateyUnzip @packageArgs
 
 $packageArgs2 = @{
   PackageName    = $packageName
-  FileFullPath   = Get-Item $toolsDir\*_i386.tar
-  FileFullPath64 = Get-Item $toolsDir\*_x86_64.tar
+  FileFullPath64 = Get-Item $toolsDir\k9s_Windows_x86_64.tar
   Destination    = $toolsDir
 }
 

--- a/automatic/k9s/update.ps1
+++ b/automatic/k9s/update.ps1
@@ -6,7 +6,6 @@ Import-Module AU
 $domain   = 'https://github.com'
 $releases = "$domain/derailed/k9s/releases/latest"
 
-$filename32 = 'k9s_Windows_i386.tar.gz'
 $filename64 = 'k9s_Windows_x86_64.tar.gz'
 
 function global:au_BeforeUpdate {
@@ -16,10 +15,8 @@ function global:au_BeforeUpdate {
 function global:au_SearchReplace {
   @{
     ".\legal\VERIFICATION.txt" = @{
-      "(?i)(^\s*32\-bit software.*)\<.*\>" = "`${1}<$($Latest.URL32)>"
       "(?i)(^\s*64\-bit software.*)\<.*\>" = "`${1}<$($Latest.URL64)>"
-      "(?i)(^\s*checksum\s*type\:).*"      = "`${1} $($Latest.ChecksumType32)"
-      "(?i)(^\s*checksum(32)?\:).*"        = "`${1} $($Latest.Checksum32)"
+      "(?i)(^\s*checksum\s*type\:).*"      = "`${1} $($Latest.ChecksumType64)"
       "(?i)(^\s*checksum(64)?\:).*"        = "`${1} $($Latest.Checksum64)"
     }
 
@@ -39,18 +36,14 @@ function global:au_GetLatest {
 
   $checksumAsset = $domain + ($download_page.Links | ? href -match "checksums\.txt$" | select -first 1 -expand href)
   $checksum_page = Invoke-WebRequest -Uri $checksumAsset -UseBasicParsing
-  $checksum32 = [regex]::Match($checksum_page, "([a-f\d]+)\s*$([regex]::Escape($filename32))").Groups[1].Value
   $checksum64 = [regex]::Match($checksum_page, "([a-f\d]+)\s*$([regex]::Escape($filename64))").Groups[1].Value
   
   return @{
     Version        = $version
-    URL32          = "$domain/derailed/k9s/releases/download/v${version}/${filename32}"
     URL64          = "$domain/derailed/k9s/releases/download/v${version}/${filename64}"
     ReleaseNotes   = "$domain/derailed/k9s/blob/v${version}/change_logs/release_v${version}.md"
     ReleaseURL     = "$domain/derailed/k9s/releases/tag/v${version}"
-    Checksum32     = $checksum32
     Checksum64     = $checksum64
-    ChecksumType32 = "sha256"
     ChecksumType64 = "sha256"
   }
 }


### PR DESCRIPTION
## Description

Remove 32bit version support

## Motivation and Context

update.ps1 script no longer works because new releases does not contains the 32 bit exe file.

https://github.com/derailed/k9s/releases/tag/v0.19.3

## How Has this Been Tested?

contains minimal changes tested locally


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
