### PR TITLE
(msys2) update to working version

### DIFF
--- a/automatic/msys2/legal/VERIFICATION.txt
+++ b/automatic/msys2/legal/VERIFICATION.txt
@@ -7,8 +7,8 @@ Package can be verified like this:
 
 1. Go to
 
-   x32: http://repo.msys2.org/distrib/i686/msys2-base-i686-20190524.tar.xz
-   x64: http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz
+   x32: https://github.com/msys2/msys2-installer/releases/download/2020-05-17/msys2-base-i686-20200517.tar.xz
+   x64: https://github.com/msys2/msys2-installer/releases/download/2020-05-17/msys2-base-x86_64-20200517.tar.xz
 
    to download the installer.
 
@@ -16,8 +16,8 @@ Package can be verified like this:
    - Use powershell function 'Get-FileHash'
    - Use Chocolatey utility 'checksum.exe'
 
-   checksum32: 7A463AFAE8BF6CE8262F010A9A1648D056AD5CEFC66D6EB69FE948C57D4CCB53
-   checksum64: 168E156FA9F00D90A8445676C023C63BE6E82F71487F4E2688AB5CB13B345383
+   checksum32: 4DBDDE708A4BCF3C056E8F4F28B1B0E7A3210FFACC6296A7D11FDAF076FD431E
+   checksum64: C4443113497ACB2D2E285D40B929FC55F33F8F669902595ECDF66A655B63DC60
 
 File 'LICENSE.txt' is obtained from:
    https://raw.githubusercontent.com/Alexpux/MSYS2-packages/master/LICENSE

--- a/automatic/msys2/msys2.nuspec
+++ b/automatic/msys2/msys2.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>msys2</id>
-    <version>20190524.0.0</version>
+    <version>20200517.0.0</version>
     <title>MSYS2</title>
     <authors>Alexpux, martell, mingwandroid, elieux, renatosilva, niXman</authors>
     <owners>chocolatey, userzimmermann, petemounce</owners>

--- a/automatic/msys2/tools/helpers.ps1
+++ b/automatic/msys2/tools/helpers.ps1
@@ -35,7 +35,7 @@ function Update-MSys2 {
     $logPath      = Join-Path $InstallPath update.log
     $stopSentence = 'there is nothing to do'
     $cntSentence  = 2
-    $shellArgs    = "pacman --noconfirm -Syuu | tee -a /update.log"
+    $shellArgs    = "pacman --noconfirm -Syuu --disable-download-timeout | tee -a /update.log"
     $max          = 5  
 
     Write-Host "Repeating system update until there are no more updates or max $max iterations"

--- a/automatic/msys2/update.ps1
+++ b/automatic/msys2/update.ps1
@@ -1,6 +1,6 @@
 import-module au
 
-$releases = 'http://repo.msys2.org/distrib'
+$releases = 'https://github.com/msys2/msys2-installer/releases/latest'
 
 function global:au_SearchReplace {
    @{
@@ -16,15 +16,17 @@ function global:au_SearchReplace {
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 
 function global:au_GetLatest {
-    $re = '\.xz$'
+    $re32 = 'msys2-base-i686-(\d+)\.tar\.xz$'
+    $re64 = 'msys2-base-x86_64-(\d+)\.tar\.xz$'
 
-    $download_page = Invoke-WebRequest -Uri "$releases/i686" -UseBasicParsing
-    $url32 = $download_page.Links | ? href -match $re | select -Last 1 | % { "$releases/i686/" + $_.href }
-    $version32 = $url32 -split '/|-|\.' | select -Last 1 -Skip 2
+    $baseUrl = $([System.Uri]$releases).Scheme + '://' + $([System.Uri]$releases).Authority
 
-    $download_page = Invoke-WebRequest -Uri "$releases/x86_64" -UseBasicParsing
-    $url64 = $download_page.Links | ? href -match $re | select -Last 1 | % { "$releases/x86_64/" + $_.href }
-    $version64 = $url64 -split '/|-|\.' | select -Last 1 -Skip 2
+    $download_page = Invoke-WebRequest -Uri "$releases" -UseBasicParsing
+    $url32 = $download_page.Links | ? href -match $re32 | select -First 1 | % { "$baseUrl" + $_.href }
+    $version32 = [regex]::match($url32,$re32).Groups[1].Value
+
+    $url64 = $download_page.Links | ? href -match $re64 | select -First 1 | % { "$baseUrl" + $_.href }
+    $version64 = [regex]::match($url64,$re64).Groups[1].Value
 
     if ($version32 -ne $version64) { throw "x32 and x64 versions are not the same" }
 


### PR DESCRIPTION
## Description
After latest changes in msys2 chololatey package is not installing anymore

## Motivation and Context
Fixes #1479 

## How Has this Been Tested?
In docker container with chocolatey installed:
```
choco pack
choco install chocolatey-core.extension
choco install msys2.20200517.0.0.nupkg
```
Dockerfile
```
FROM mcr.microsoft.com/windows:1909
ENV chocolateyUseWindowsCompression false
RUN powershell -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && rmdir /s/q "%temp%" && mkdir "%temp%" && del /q %ProgramData%\chocolatey\logs\*
RUN choco feature enable -n=allowGlobalConfirmation && rmdir /s/q "%temp%" && mkdir "%temp%" && del /q %ChocolateyInstall%\logs\*
RUN choco feature disable -n=showDownloadProgress && rmdir /s/q "%temp%" && mkdir "%temp%" && del /q %ChocolateyInstall%\logs\*

```

## Screenshot (if appropriate, usually isn't needed):
```
C:\choco\automatic\msys2>choco install msys2.20200517.0.0.nupkg
The use of .nupkg or .nuspec in for package name or source is known to cause issues. Please use the package id from the nuspec `<id />` with `-s .` (for local folder where nupkg is found).
Chocolatey v0.10.15
Installing the following packages:
msys2.20200517.0.0.nupkg
By installing you accept licenses for the packages.

msys2 v20200517.0.0
msys2 package files install completed. Performing other installation steps.
Installing to: C:\tools\msys64
Extracting 64-bit C:\ProgramData\chocolatey\lib\msys2\tools\msys2-base-x86_64-20200517.tar.xz to C:\tools\msys64...
C:\tools\msys64
Extracting C:\tools\msys64\msys2-base-x86_64-20200517.tar to C:\tools\msys64...
C:\tools\msys64
Invoking first run to setup things like bash profile, gpg etc...
Invoking msys2 shell command: -defterm -no-start -c "ps -ef | grep '[?]' | awk '{print $2}' | xargs -r kill"
mkdir: cannot change permissions of '/dev/shm': Permission denied
mkdir: cannot change permissions of '/dev/mqueue': Permission denied
'C:\Windows\system32\drivers\etc\hosts' -> '/etc/hosts'
'C:\Windows\system32\drivers\etc\protocol' -> '/etc/protocols'
'C:\Windows\system32\drivers\etc\services' -> '/etc/services'
'C:\Windows\system32\drivers\etc\networks' -> '/etc/networks'
gpg: /etc/pacman.d/gnupg/trustdb.gpg: trustdb created
gpg: no ultimately trusted keys found
gpg: starting migration from earlier GnuPG versions
gpg: porting secret keys from '/etc/pacman.d/gnupg/secring.gpg' to gpg-agent
gpg: migration succeeded
gpg: Generating pacman keyring master key...
gpg: key 78C313BDD0E0EC56 marked as ultimately trusted
gpg: directory '/etc/pacman.d/gnupg/openpgp-revocs.d' created
gpg: revocation certificate stored as '/etc/pacman.d/gnupg/openpgp-revocs.d/A19D64EE596E263C9819F00078C313BDD0E0EC56.rev'
gpg: Done
==> Updating trust database...
gpg: marginals needed: 3  completes needed: 1  trust model: pgp
gpg: depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u
==> Appending keys from msys2.gpg...
==> Locally signing trusted keys in keyring...
  -> Locally signing key D55E7A6D7CE9BA1587C0ACACF40D263ECA25678A...
  -> Locally signing key 123D4D51A1793859C2BE916BBBE514E53E0D0813...
  -> Locally signing key B91BCF3303284BF90CC043CA9F418C233E652008...


###################################################################
#                                                                 #
#                                                                 #
#                   C   A   U   T   I   O   N                     #
#                                                                 #
#                  This is first start of MSYS2.                  #
#       You MUST restart shell to apply necessary actions.        #
#                                                                 #
#                                                                 #
###################################################################


Repeating system update until there are no more updates or max 5 iterations
Output is recorded in: C:\tools\msys64\update.log

================= SYSTEM UPDATE 1 =================

Invoking msys2 shell command: -defterm -no-start -c "pacman --noconfirm -Syuu --disable-download-timeout | tee -a /update.log; ps -ef | grep '[?]' | awk '{print $2}' | xargs -r kill"
:: Synchronizing package databases...
 mingw32 is up to date
 mingw64 is up to date
downloading msys.db...
downloading msys.db.sig...
:: Starting core system upgrade...
warning: terminate other MSYS2 programs before proceeding
resolving dependencies...
looking for conflicting packages...

Packages (2) msys2-runtime-3.1.4-2  pacman-5.2.1-7

Total Download Size:   16.80 MiB
Total Installed Size:  50.85 MiB
Net Upgrade Size:       1.05 MiB

:: Proceed with installation? [Y/n]
:: Retrieving packages...
downloading msys2-runtime-3.1.4-2-x86_64.pkg.tar.zst...
downloading pacman-5.2.1-7-x86_64.pkg.tar.zst...
checking keyring...
checking package integrity...
loading package files...
checking for file conflicts...
checking available disk space...
:: Processing package changes...
upgrading msys2-runtime...
upgrading pacman...
warning: terminate MSYS2 without returning to shell and check for updates again
warning: for example close your terminal window instead of calling exit
      0 [main] bash (3048) C:\tools\msys64\usr\bin\bash.exe: *** fatal error - cygheap base mismatch detected - 0x180317408/0x18033E408.
This problem is probably due to using incompatible versions of the cygwin DLL.
Search for cygwin1.dll using the Windows Start->Find/Search facility
and delete all but the most recent version.  The most recent version *should*
reside in x:\cygwin\bin, where 'x' is the drive on which you have
installed the cygwin distribution.  Rebooting is also suggested if you
are unable to find another cygwin DLL.
      0 [main] bash 1719 dofork: child -1 - forked process 3048 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
/usr/bin/bash: fork: retry: Resource temporarily unavailable
      0 [main] bash (2388) C:\tools\msys64\usr\bin\bash.exe: *** fatal error - cygheap base mismatch detected - 0x180317408/0x18033E408.
This problem is probably due to using incompatible versions of the cygwin DLL.
Search for cygwin1.dll using the Windows Start->Find/Search facility
and delete all but the most recent version.  The most recent version *should*
reside in x:\cygwin\bin, where 'x' is the drive on which you have
installed the cygwin distribution.  Rebooting is also suggested if you
are unable to find another cygwin DLL.
1027925 [main] bash 1719 dofork: child -1 - forked process 2388 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
/usr/bin/bash: fork: retry: Resource temporarily unavailable
      0 [main] bash (1112) C:\tools\msys64\usr\bin\bash.exe: *** fatal error - cygheap base mismatch detected - 0x180317408/0x18033E408.
This problem is probably due to using incompatible versions of the cygwin DLL.
Search for cygwin1.dll using the Windows Start->Find/Search facility
and delete all but the most recent version.  The most recent version *should*
reside in x:\cygwin\bin, where 'x' is the drive on which you have
installed the cygwin distribution.  Rebooting is also suggested if you
are unable to find another cygwin DLL.
3044418 [main] bash 1719 dofork: child -1 - forked process 1112 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
/usr/bin/bash: fork: retry: Resource temporarily unavailable
      0 [main] bash (1252) C:\tools\msys64\usr\bin\bash.exe: *** fatal error - cygheap base mismatch detected - 0x180317408/0x18033E408.
This problem is probably due to using incompatible versions of the cygwin DLL.
Search for cygwin1.dll using the Windows Start->Find/Search facility
and delete all but the most recent version.  The most recent version *should*
reside in x:\cygwin\bin, where 'x' is the drive on which you have
installed the cygwin distribution.  Rebooting is also suggested if you
are unable to find another cygwin DLL.
7059733 [main] bash 1719 dofork: child -1 - forked process 1252 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
/usr/bin/bash: fork: retry: Resource temporarily unavailable
      0 [main] bash (2728) C:\tools\msys64\usr\bin\bash.exe: *** fatal error - cygheap base mismatch detected - 0x180317408/0x18033E408.
This problem is probably due to using incompatible versions of the cygwin DLL.
Search for cygwin1.dll using the Windows Start->Find/Search facility
and delete all but the most recent version.  The most recent version *should*
reside in x:\cygwin\bin, where 'x' is the drive on which you have
installed the cygwin distribution.  Rebooting is also suggested if you
are unable to find another cygwin DLL.
15075653 [main] bash 1719 dofork: child -1 - forked process 2728 died unexpectedly, retry 0, exit code 0xC0000142, errno 11
/usr/bin/bash: fork: Resource temporarily unavailable

================= SYSTEM UPDATE 2 =================

Invoking msys2 shell command: -defterm -no-start -c "pacman --noconfirm -Syuu --disable-download-timeout | tee -a /update.log; ps -ef | grep '[?]' | awk '{print $2}' | xargs -r kill"
:: Synchronizing package databases...
 mingw32 is up to date
 mingw64 is up to date
 msys is up to date
:: Starting core system upgrade...
 there is nothing to do
:: Starting full system upgrade...
resolving dependencies...
looking for conflicting packages...

Packages (10) bsdcpio-3.4.2-3  bsdtar-3.4.2-3  libarchive-3.4.2-3  libgnutls-3.6.13-2  libgpgme-1.13.1-4  libhogweed-3.6-1  libnettle-3.6-1  libpcre2_8-10.35-1  nettle-3.6-1  u-boot-tools-2020.04-2

Total Download Size:    5.67 MiB
Total Installed Size:  17.74 MiB
Net Upgrade Size:       0.03 MiB

:: Proceed with installation? [Y/n]
:: Retrieving packages...
downloading libhogweed-3.6-1-x86_64.pkg.tar.zst...
downloading libnettle-3.6-1-x86_64.pkg.tar.zst...
downloading bsdcpio-3.4.2-3-x86_64.pkg.tar.zst...
downloading bsdtar-3.4.2-3-x86_64.pkg.tar.zst...
downloading libarchive-3.4.2-3-x86_64.pkg.tar.zst...
downloading libgnutls-3.6.13-2-x86_64.pkg.tar.zst...
downloading nettle-3.6-1-x86_64.pkg.tar.zst...
downloading libgpgme-1.13.1-4-x86_64.pkg.tar.zst...
downloading libpcre2_8-10.35-1-x86_64.pkg.tar.zst...
downloading u-boot-tools-2020.04-2-x86_64.pkg.tar.zst...
checking keyring...
checking package integrity...
loading package files...
checking for file conflicts...
checking available disk space...
:: Processing package changes...
upgrading libhogweed...
upgrading libnettle...
upgrading bsdcpio...
upgrading bsdtar...
upgrading libarchive...
upgrading libgnutls...
upgrading nettle...
upgrading libgpgme...
upgrading libpcre2_8...
upgrading u-boot-tools...

================= SYSTEM UPDATE 3 =================

Invoking msys2 shell command: -defterm -no-start -c "pacman --noconfirm -Syuu --disable-download-timeout | tee -a /update.log; ps -ef | grep '[?]' | awk '{print $2}' | xargs -r kill"
:: Synchronizing package databases...
 mingw32 is up to date
 mingw64 is up to date
 msys is up to date
:: Starting core system upgrade...
 there is nothing to do
:: Starting full system upgrade...
 there is nothing to do
PATH environment variable does not have C:\tools\msys64 in it. Adding...
Environment Vars (like PATH) have changed. Close/reopen your shell to
 see the changes (or in powershell/cmd.exe just type `refreshenv`).
 The install of msys2 was successful.
  Software installed to 'C:\tools\msys64'

Chocolatey installed 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

C:\choco\automatic\msys2>choco uninstall msys2
Chocolatey v0.10.15
Uninstalling the following packages:
msys2

msys2 v20200517.0.0
Removing from user PATH
Please remove install dir manually when you don't need it anymore.
Install dir:  C:\tools\msys64
 Skipping auto uninstaller - No registry snapshot.
 msys2 has been successfully uninstalled.
Environment Vars (like PATH) have changed. Close/reopen your shell to
 see the changes (or in powershell/cmd.exe just type `refreshenv`).

Chocolatey uninstalled 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
