### PR TITLE
(FlightGear) Update update.ps1

### DIFF
--- a/automatic/flightgear/tools/chocolateyInstall.ps1
+++ b/automatic/flightgear/tools/chocolateyInstall.ps1
@@ -10,9 +10,6 @@ $packageArgs = @{
 
   softwareName = $softwareName
 
-  checksum     = '8B1851999233047E3DA451AFB2739C5024E914E92011B3F5F37E42CDB5ED1F64'
-  checksumType = ''
-
   silentArgs   = '/VERYSILENT'
   validExitCodes = @(0)
 }

--- a/automatic/flightgear/update.ps1
+++ b/automatic/flightgear/update.ps1
@@ -2,7 +2,7 @@
 
 # We can't use https for the url, otherwise powershell throws an error and closes the window.
 # Oddly it works when choco auto redirects http to https
-$downloads = 'http://ftp.igh.cnrs.fr/pub/flightgear/ftp'
+$downloads = 'https://sourceforge.net/projects/flightgear/files'
 $changelog = 'http://wiki.flightgear.org/Changelog_'
 $versions = 'http://www.flightgear.org/'
 
@@ -10,8 +10,6 @@ function global:au_SearchReplace {
   @{
     ".\tools\chocolateyInstall.ps1" = @{
       "(?i)(^\s*url\s*=\s*)('.*')"            = "`$1'$($Latest.URL32)'"
-      "(?i)(^\s*checksum\s*=\s*)('.*')"       = "`$1'$(Get-RemoteChecksum -Url $Latest.URL32)'"
-      "(?i)(^\s*checksumType\s*=\s*)('.*')"   = "`$1'sha256'"
       "(?i)(^[$]version\s*=\s*)('.*')"        = "`$1'$($Latest.RemoteVersion)'"
     }
     ".\$($Latest.PackageName).nuspec" = @{
@@ -32,7 +30,7 @@ function global:au_GetLatest {
     throw "Cannot obtain the latest version from FlightGear's homepage, please update the `"update.ps1`" script."
   }
 
-  $url = "$downloads/release-$short_version/FlightGear-$version.exe"
+  $url = "$downloads/release-$short_version/FlightGear-$version.exe/download"
 
   $releaseNotes = "$changelog$short_version"
 


### PR DESCRIPTION
## Description
Updated auto-update script
Now tracking stable releases scraping the homepage

## Motivation and Context
Newer releases are no longer uploaded to the Windows folder on ftp's since Nov2016, so the updater got stuck.

## How Has this Been Tested?
Copy-Paste parts of the script on the W10 PowerShell prompt to ensure output validity.
Script as a whole not tested.
```
> $PSVersionTable

Name                           Value
----                           -----
PSVersion                      5.1.18362.752
PSEdition                      Desktop
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
BuildVersion                   10.0.18362.752
CLRVersion                     4.0.30319.42000
WSManStackVersion              3.0
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
````

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
