### PR TITLE
(nomacs)/.portable - use github release page instead of outdated nomacs website

### DIFF
--- a/automatic/nomacs.portable/update.ps1
+++ b/automatic/nomacs.portable/update.ps1
@@ -25,7 +25,7 @@ function global:au_BeforeUpdate { Get-RemoteFiles -NoSuffix -Purge }
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
     $url     = $download_page.links | ? href -like '*/nomacs-*' | % href | select -First 1
-    $version = $url -split '-|\.zip' | select -Last 1 -Skip 1
+    $version = $url -split '\/' | select -Last 1 -Skip 1
     @{
         Version      = $version
         URL64        = $url

--- a/automatic/nomacs.portable/update.ps1
+++ b/automatic/nomacs.portable/update.ps1
@@ -24,11 +24,11 @@ function global:au_BeforeUpdate { Get-RemoteFiles -NoSuffix -Purge }
 
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-    $url     = $download_page.links | ? href -like '*/nomacs-*' | % href | select -First 1
+    $url     = $download_page.links | ? href -like '*/nomacs-*.zip' | % href | select -First 1
     $version = $url -split '\/' | select -Last 1 -Skip 1
     @{
         Version      = $version
-        URL64        = $url
+        URL64        = "https://github.com/${url}"
         ReleaseNotes = "https://github.com/nomacs/nomacs/releases/tag/${version}"
         FileName     = $url -split '/' | select -last 1
     }

--- a/automatic/nomacs.portable/update.ps1
+++ b/automatic/nomacs.portable/update.ps1
@@ -1,6 +1,6 @@
 import-module au
 
-$releases = 'http://download.nomacs.org/versions'
+$releases = 'https://github.com/nomacs/nomacs/releases'
 
 function global:au_SearchReplace {
    @{

--- a/automatic/nomacs/update.ps1
+++ b/automatic/nomacs/update.ps1
@@ -5,9 +5,7 @@ $releases = 'https://github.com/nomacs/nomacs/releases'
 function global:au_SearchReplace {
    @{
         ".\legal\VERIFICATION.txt" = @{
-            "(?i)(\s+x32:).*"            = "`${1} $($Latest.URL32)"
             "(?i)(\s+x64:).*"            = "`${1} $($Latest.URL64)"
-            "(?i)(checksum32:).*"        = "`${1} $($Latest.Checksum32)"
             "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum64)"
         }
 
@@ -25,8 +23,7 @@ function global:au_GetLatest {
     $version = $url -split '\/' | select -Last 1 -Skip 1
     @{
         Version      = $version
-        URL64        = 'http://download.nomacs.org/nomacs-setup-x64.msi'
-        URL32        = 'http://download.nomacs.org/nomacs-setup-x86.msi'
+        URL64        = "https://github.com/${url}"
         ReleaseNotes = "https://github.com/nomacs/nomacs/releases/tag/${version}"
     }
 }

--- a/automatic/nomacs/update.ps1
+++ b/automatic/nomacs/update.ps1
@@ -22,7 +22,7 @@ function global:au_BeforeUpdate  { Get-RemoteFiles -NoSuffix -Purge }
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
     $url     = $download_page.links | ? href -like '*/nomacs-*' | % href | select -First 1
-    $version = $url -split '-|\.zip' | select -Last 1 -Skip 1
+    $version = $url -split '\/' | select -Last 1 -Skip 1
     @{
         Version      = $version
         URL64        = 'http://download.nomacs.org/nomacs-setup-x64.msi'

--- a/automatic/nomacs/update.ps1
+++ b/automatic/nomacs/update.ps1
@@ -21,7 +21,7 @@ function global:au_BeforeUpdate  { Get-RemoteFiles -NoSuffix -Purge }
 
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-    $url     = $download_page.links | ? href -like '*/nomacs-*' | % href | select -First 1
+    $url     = $download_page.links | ? href -like '*/nomacs-*x64.msi' | % href | select -First 1
     $version = $url -split '\/' | select -Last 1 -Skip 1
     @{
         Version      = $version

--- a/automatic/nomacs/update.ps1
+++ b/automatic/nomacs/update.ps1
@@ -1,6 +1,6 @@
 import-module au
 
-$releases = 'http://download.nomacs.org/versions'
+$releases = 'https://github.com/nomacs/nomacs/releases'
 
 function global:au_SearchReplace {
    @{


### PR DESCRIPTION
nomacs/nomacs.portable: the previously used page to check for new releases doesn't seem to be updated by the software maintainers any more, directly use the GitHub release page instead.

verified it actually get's the correct version by manually running the iwr & regex - link match in powershell.

