### PR TITLE
Fix keeweb

### DIFF
--- a/automatic/keeweb/tools/chocolateyUninstall.ps1
+++ b/automatic/keeweb/tools/chocolateyUninstall.ps1
@@ -4,8 +4,13 @@ $installerType = 'exe'
 
 $silentArgs = '/S'
 # It seems weird, but actually the uninstaller always returns 2 as exit code.
+#  Uninstalling keeweb...
+#  WARNING: Setup was cancelled.
+#  WARNING: Exit code '2' was considered valid by script, but not as a Chocolatey success code. Returning '0'.
+#  0
+#  keeweb has been uninstalled.
 # We cannot rely on choco autouninstaller feature, otherwise the uninstall
-# process will be considered as a failure (tests will fail).
+# process will be considered as a failure (and tests performed by Chocolatey will fail).
 $validExitCodes = @(2)
 
 [array]$key = Get-UninstallRegistryKey -SoftwareName $softwareName

--- a/automatic/keeweb/update.ps1
+++ b/automatic/keeweb/update.ps1
@@ -1,80 +1,69 @@
 import-module au
 
-$releases = 'https://github.com/keeweb/keeweb/releases'
-
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 
 function global:au_SearchReplace {
-    @{
-        ".\legal\verification.txt" = @{
-            "(?i)(32-Bit.+)\<.*\>" = "`${1}<$($Latest.URL32)>"
-            "(?i)(64-Bit.+)\<.*\>" = "`${1}<$($Latest.URL64)>"
-            "(?i)(checksum type:\s+).*" = "`${1}$($Latest.ChecksumType64)"
-            "(?i)(checksum32:\s+).*" = "`${1}$($Latest.Checksum32)"
-            "(?i)(checksum64:\s+).*" = "`${1}$($Latest.Checksum64)"
-        }
-        ".\tools\chocolateyInstall.ps1" = @{
-            "(?i)(^\s*file\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName32)`""
-            "(?i)(^\s*file64\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName64)`""
-        }
+  @{
+    ".\legal\verification.txt" = @{
+      "(?i)(32-Bit.+)\<.*\>" = "`${1}<$($Latest.URL32)>"
+      "(?i)(64-Bit.+)\<.*\>" = "`${1}<$($Latest.URL64)>"
+      "(?i)(checksum type:\s+).*" = "`${1}$($Latest.ChecksumType64)"
+      "(?i)(checksum32:\s+).*" = "`${1}$($Latest.Checksum32)"
+      "(?i)(checksum64:\s+).*" = "`${1}$($Latest.Checksum64)"
     }
+    ".\tools\chocolateyInstall.ps1" = @{
+      "(?i)(^\s*file\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName32)`""
+      "(?i)(^\s*file64\s*=\s*`"[$]toolsPath\\).*" = "`${1}$($Latest.FileName64)`""
+    }
+  }
 }
 
 function global:au_GetLatest {
 
-    $downloadedPage = Invoke-WebRequest -Uri $releases -UseBasicParsing
-
-    $baseUrl = $([System.Uri]$releases).Authority
-    $scheme = $([System.Uri]$releases).Scheme
-
-    $url32 = $downloadedPage.links | ? href -match '32.exe$' | select -First 1 -expand href
-    if ($url32.Authority -cnotmatch $baseUrl) {
-        $url32 = $scheme + '://' + $baseUrl + $url32
+  $jsonAnswer = (
+    Invoke-WebRequest -Uri "https://api.github.com/repos/keeweb/keeweb/releases/latest" `
+                      -Headers @{"Authorization"="token $env:github_api_key"} `
+                      -UseBasicParsing).Content | ConvertFrom-Json
+  $version = $jsonAnswer.tag_name -Replace '[^0-9.]'
+  $jsonAnswer.assets |Where { $_.name -cmatch "(32|x64).exe" } | ForEach-Object {
+    if ($_.browser_download_url -Match 'x64') {
+      $url64 = $_.browser_download_url
+      $filename64 = $_.name
+    } else {
+      $url32 = $_.browser_download_url
+      $filename32 = $_.name
     }
-    $url32SegmentSize = $([System.Uri]$url32).Segments.Length
-    $filename32 = $([System.Uri]$url32).Segments[$url32SegmentSize - 1]
+  }
 
-    $url64 = $downloadedPage.links | ? href -match 'x64.exe$' | select -First 1 -expand href
-    if ($url64.Authority -cnotmatch $baseUrl) {
-        $url64 = $scheme + '://' + $baseUrl + $url64
+  # Since upstream is providing hashes, let's rely on these instead.
+  # i.e. this adds some added value as we are making sure the hashes are
+  # really those computed by upstream. We are not simply relying on the hashs
+  # provided by the cmdlet Get-RemoteFiles.
+  $verifyUrl = ($jsonAnswer.assets | Where { $_.name -Match "Verify.sha256" }).browser_download_url
+  $downloadedPage = Invoke-WebRequest -Uri $verifyUrl -UseBasicParsing
+  $downloadedPage = [System.Text.Encoding]::UTF8.GetString($downloadedPage.Content)
+  $downloadedPage = $downloadedPage.Split([Environment]::NewLine)
+  foreach ($line in $downloadedPage) {
+    $parsed = $line -split ' |\n' -replace '\*',''
+    if ($parsed[1] -cmatch $filename32) {
+      $hash32 = $parsed[0]
     }
-    $url64SegmentSize = $([System.Uri]$url64).Segments.Length
-    $filename64 = $([System.Uri]$url64).Segments[$url64SegmentSize - 1]
-
-    $version = [regex]::match($url32,'/[A-Za-z]+-([0-9]+.[0-9]+.[0-9]+).*exe').Groups[1].Value
-
-    # Since upstream is providing hashes, let's rely on these instead.
-    # i.e. this adds some added value as we are making sure the hashes are
-    # really those computed by upstream. We are not simply relying on the hashs
-    # provided by the cmdlet Get-RemoteFiles.
-    $verifyUrl = $releases + '/download/VERSION/Verify.sha256'
-    $verifyUrl = $verifyUrl -Replace 'VERSION',"v$version"
-    $downloadedPage = Invoke-WebRequest -Uri $verifyUrl -UseBasicParsing
-    $downloadedPage = [System.Text.Encoding]::UTF8.GetString($downloadedPage.Content)
-    $downloadedPage = $downloadedPage.Split([Environment]::NewLine)
-
-    foreach ($line in $downloadedPage) {
-
-        $parsed = $line -split ' |\n' -replace '\*',''
-
-        if ($parsed[1] -cmatch $filename32) {
-            $hash32 = $parsed[0]
-        }
-        if ($parsed[1] -cmatch $filename64) {
-            $hash64 = $parsed[0]
-        }
+    if ($parsed[1] -cmatch $filename64) {
+      $hash64 = $parsed[0]
     }
-    return @{
-        url32 = $url32;
-        url64 = $url64;
-        checksum32 = $hash32;
-        checksum64 = $hash64;
-        checksumType32 = 'SHA256';
-        checksumType64 = 'SHA256';
-        filename32 = $filename32;
-        filename64 = $filename64;
-        version = $version;
-    }
+  }
+
+  return @{
+    url32 = $url32;
+    url64 = $url64;
+    checksum32 = $hash32;
+    checksum64 = $hash64;
+    checksumType32 = 'SHA256';
+    checksumType64 = 'SHA256';
+    filename32 = $filename32;
+    filename64 = $filename64;
+    version = $version;
+  }
 }
 
 update -ChecksumFor none


### PR DESCRIPTION
## Description
Keeweb added an arm 64 version of the exe which was breaking the x64 detection. Fix that.

## Motivation and Context
Take the opportunity to use the GitHub API rather than the HTML parsing.

## How Has this Been Tested?
On local Windows 7 and Windows 10 dev based environment + the test instance of the verifier.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).

