### PR TITLE
(keepassxc) Ensure beta versions are not detected by using GitHub API

### DIFF
--- a/automatic/keepassxc/keepassxc.nuspec
+++ b/automatic/keepassxc/keepassxc.nuspec
@@ -6,7 +6,7 @@
   <metadata>
     <id>keepassxc</id>
     <title>KeePassXC</title>
-    <version>2.6.0-beta1</version>
+    <version>2.5.4</version>
     <authors>https://github.com/keepassxreboot/keepassxc/graphs/contributors</authors>
     <owners>wget, hans0</owners>
     <summary>KeePassXC is a community fork of KeePassX which aims to incorporate stalled pull requests, features, and bug fixes that have never made it into the main KeePassX repository.</summary>

--- a/automatic/keepassxc/legal/VERIFICATION.txt
+++ b/automatic/keepassxc/legal/VERIFICATION.txt
@@ -6,14 +6,14 @@ The installer have been downloaded from the Github release page <https://github.
 and can be verified like this:
 
 1.  Download the following installers:
-    32-Bit: <https://github.com/keepassxreboot/keepassxc/releases/download/2.6.0-beta1/KeePassXC-2.6.0-beta1-Win32.msi>
-    64-Bit: <https://github.com/keepassxreboot/keepassxc/releases/download/2.6.0-beta1/KeePassXC-2.6.0-beta1-Win64.msi>
+    32-Bit: <https://github.com/keepassxreboot/keepassxc/releases/download/2.5.4/KeePassXC-2.5.4-Win64.msi>
+    64-Bit: <https://github.com/keepassxreboot/keepassxc/releases/download/2.5.4/KeePassXC-2.5.4-Win64.msi>
 2.  You can use one of the following methods to obtain the checksum
     - Use powershell function 'Get-Filehash'
     - Use chocolatey utility 'checksum.exe'
 
     checksum type: sha256
-    checksum32: 021167A1FF4978E8427B112DF88C236FCD7E5F00844794A646D3D2D07544A230
-    checksum64: 9F6FD3C1B3E9186EC88686AA7DDF196A421496205699759A1682A6B15B2A50B3
+    checksum32: 01BF1B593EFC4A9B92E0CA7148414F6D4F0E63521AEFA64D1F8CAA0327D35E91
+    checksum64: 01BF1B593EFC4A9B92E0CA7148414F6D4F0E63521AEFA64D1F8CAA0327D35E91
 
 File 'LICENSE.txt' is obtained from <https://github.com/keepassxreboot/keepassxc/blob/470a74ee24793eaccab0ae371a7ee970b95bfeb9/COPYING>

--- a/automatic/keepassxc/tools/chocolateyInstall.ps1
+++ b/automatic/keepassxc/tools/chocolateyInstall.ps1
@@ -6,11 +6,11 @@ $packageArgs = @{
   packageName    = 'keepassxc'
   softwareName   = 'KeePassXC'
   fileType       = 'msi'
-  file           = "$toolsDir\KeePassXC-2.6.0-beta1-Win32.msi"
-  file64         = "$toolsDir\KeePassXC-2.6.0-beta1-Win64.msi"
-  checksum       = '021167A1FF4978E8427B112DF88C236FCD7E5F00844794A646D3D2D07544A230'
+  file           = "$toolsDir\KeePassXC-2.5.4-Win64.msi"
+  file64         = "$toolsDir\KeePassXC-2.5.4-Win64.msi"
+  checksum       = '01BF1B593EFC4A9B92E0CA7148414F6D4F0E63521AEFA64D1F8CAA0327D35E91'
   checksumType   = 'sha256'
-  checksum64     = '9F6FD3C1B3E9186EC88686AA7DDF196A421496205699759A1682A6B15B2A50B3'
+  checksum64     = '01BF1B593EFC4A9B92E0CA7148414F6D4F0E63521AEFA64D1F8CAA0327D35E91'
   checksumType64 = 'sha256'
 
   # MSI

--- a/automatic/keepassxc/update.ps1
+++ b/automatic/keepassxc/update.ps1
@@ -1,7 +1,5 @@
 import-module au
 
-$releases = 'https://github.com/keepassxreboot/keepassxc/releases'
-
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge -NoSuffix }
 
 function global:au_SearchReplace {
@@ -22,28 +20,52 @@ function global:au_SearchReplace {
   }
 }
 
-function appendBaseIfNeeded([string]$url) {
-  if ($url -and !$url.StartsWith("http")) {
-    return New-Object uri([uri]$releases, $url)
-  }
-  else {
-    return $url
-  }
-}
-
 function global:au_GetLatest {
-  $downloadedPage = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-  $url32 = $downloadedPage.links | ? href -match 'Win32.msi$' | select -First 1 -expand href | % { appendBaseIfNeeded $_ }
-
-  $url64 = $downloadedPage.links | ? href -match 'Win64.msi$' | select -First 1 -expand href | % { appendBaseIfNeeded $_ }
-  $version = $url32 -split '/' | select -last 1 -skip 1
-  $nuspecVersion = gc -Encoding UTF8 "$PSScriptRoot\*.nuspec" | ? { $_ -match '\<version' } | % { $_ -replace '^\s*\<version\>(.*)\<\/version\>.*',"`$1" }
+  $jsonAnswer = (Invoke-WebRequest -Uri "https://api.github.com/repos/keepassxreboot/keepassxc/releases/latest" -UseBasicParsing).Content | ConvertFrom-Json
+  $version = $jsonAnswer.tag_name -Replace '[^0-9.]'
+  $jsonAnswer.assets | Where { $_.name -Match "(Win32|Win64).msi$" } | ForEach-Object {
+    if ($_.browser_download_url -Match 'x64') {
+      $url64 = $_.browser_download_url
+      $filename64 = $_.name
+      # Since upstream is providing hashes, let's rely on these instead.
+      # i.e. this adds some added value as we are making sure the hashes are
+      # really those computed by upstream. We are not simply relying on the hashs
+      # provided by the cmdlet Get-RemoteFiles.
+      $downloadedPage = Invoke-WebRequest -Uri "$url64.DIGEST" -UseBasicParsing
+      $downloadedPage = [System.Text.Encoding]::UTF8.GetString($downloadedPage.Content)
+      $downloadedPage = $downloadedPage.Split([Environment]::NewLine)
+      foreach ($line in $downloadedPage) {
+        $parsed = $line -split ' |\n' -replace '\*',''
+        if ($parsed[1] -Match $filename64) {
+          $hash64 = $parsed[0]
+        }
+      }
+    } else {
+      $url32 = $_.browser_download_url
+      $filename32 = $_.name
+      $downloadedPage = Invoke-WebRequest -Uri "$url64.DIGEST" -UseBasicParsing
+      $downloadedPage = [System.Text.Encoding]::UTF8.GetString($downloadedPage.Content)
+      $downloadedPage = $downloadedPage.Split([Environment]::NewLine)
+      foreach ($line in $downloadedPage) {
+        $parsed = $line -split ' |\n' -replace '\*',''
+        if ($parsed[1] -Match $filename32) {
+          $hash32 = $parsed[0]
+        }
+      }
+    }
+  }
 
   return @{
-    url32          = $url32;
-    url64          = $url64;
-    version        = $version;
+    url32 = $url32;
+    url64 = $url64;
+    checksum32 = $hash32;
+    checksum64 = $hash64;
+    checksumType32 = 'SHA256';
+    checksumType64 = 'SHA256';
+    filename32 = $filename32;
+    filename64 = $filename64;
+    version = $version;
   }
 }
 

--- a/automatic/keepassxc/update.ps1
+++ b/automatic/keepassxc/update.ps1
@@ -39,7 +39,10 @@ function Get-Hash($url, $filename) {
 
 function global:au_GetLatest {
 
-  $jsonAnswer = (Invoke-WebRequest -Uri "https://api.github.com/repos/keepassxreboot/keepassxc/releases/latest" -UseBasicParsing).Content | ConvertFrom-Json
+  $jsonAnswer = (
+    Invoke-WebRequest -Uri "https://api.github.com/repos/keepassxreboot/keepassxc/releases/latest" `
+                      -Headers @{"Authorization"="token $env:github_api_key"} `
+                      -UseBasicParsing).Content | ConvertFrom-Json
   $version = $jsonAnswer.tag_name -Replace '[^0-9.]'
   $jsonAnswer.assets | Where { $_.name -Match "(Win32|Win64).msi$" } | ForEach-Object {
     if ($_.browser_download_url -cmatch 'Win64') {


### PR DESCRIPTION
## Description
Keepassxc 2.6 beta shouldn't have been pushed. Prevent that and use the GitHub API for proper detection.

## Motivation and Context
See above.

## How Has this Been Tested?
On local Windows 7 and Windows 10 dev based environment.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).