### PR TITLE
(Keeweb) Update keeweb updater broked because of the new arm64 version

### DIFF
--- a/automatic/keeweb/update.ps1
+++ b/automatic/keeweb/update.ps1
@@ -34,7 +34,7 @@ function global:au_GetLatest {
     $url32SegmentSize = $([System.Uri]$url32).Segments.Length
     $filename32 = $([System.Uri]$url32).Segments[$url32SegmentSize - 1]
 
-    $url64 = $downloadedPage.links | ? href -match '64.exe$' | select -First 1 -expand href
+    $url64 = $downloadedPage.links | ? href -match 'x64.exe$' | select -First 1 -expand href
     if ($url64.Authority -cnotmatch $baseUrl) {
         $url64 = $scheme + '://' + $baseUrl + $url64
     }


### PR DESCRIPTION
## Description
This package filtered on 64.exe, but arm64.exe is first so the package isn't working
I've made the change for it to work.
Changed (href -match '64.exe$') into href -match 'x64.exe$'

## Motivation and Context
the package wasn't passing the verification because of the wrong system type

## How Has this Been Tested?
Tested on my computer

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).