### PR TITLE
(freecad) adding erroraction continue

### DIFF
--- a/automatic/freecad/tools/helper.ps1
+++ b/automatic/freecad/tools/helper.ps1
@@ -7,12 +7,8 @@ param(
 )
 $fileName = ((($thePackage.url64 -split('/'))[-1]) -replace( "\.$($thePackage.fileType)", '' ) )
  if ($fileName -match "portable") { 
-	if (Get-Command Get-Version -ErrorAction "Continue"){ $version = ( Get-Version $fileName ).Version;
-    [version]$version = ( ( ($version.Major),($version.Minor),($version.Build) ) -join "." )
-	} else {
-		$version = ((($thePackage.url64 -split('/'))[-2]) -replace( "[A-z]", '' ) )
-	} 
-   if ($version -ge "0.18.4") { $fileName = "conda-${version}" }
+	$version = ((($thePackage.url64 -split('/'))[-2]) -replace( "[A-z]", '' ) )
+  if ($version -ge "0.18.4") { $fileName = "conda-${version}" }
  }
 return $fileName
 }

--- a/automatic/freecad/tools/helper.ps1
+++ b/automatic/freecad/tools/helper.ps1
@@ -7,7 +7,7 @@ param(
 )
 $fileName = ((($thePackage.url64 -split('/'))[-1]) -replace( "\.$($thePackage.fileType)", '' ) )
  if ($fileName -match "portable") { 
-	if (Get-Command Get-Version){ $version = ( Get-Version $fileName ).Version;
+	if (Get-Command Get-Version -ErrorAction "Continue"){ $version = ( Get-Version $fileName ).Version;
     [version]$version = ( ( ($version.Major),($version.Minor),($version.Build) ) -join "." )
 	} else {
 		$version = ((($thePackage.url64 -split('/'))[-2]) -replace( "[A-z]", '' ) )


### PR DESCRIPTION
This will allow this package to pass verification
@AdmiringWorm @majkinetor @gep13 @pascalberger 

<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->
This package [.portable](https://chocolatey.org/packages/freecad.portable) has been stuck in verification limbo since April 19th, 2020. I had asked if this or that should be done to get this package to pass verification. The answer was always not familiar with it will get back to you.


## Description
<!-- Describe your changes in detail -->
The use of the Get-Version cmdlet causes grief if the package AU is not installed. Since all Core Packages have `$ErrorActionPreference = 'Stop';` This was causing a **_HARD Stop_** and thus causing the verification to Fail.
The cmdlet of `Get-Command` has `-erroraction` as a choice of parameters. Setting this to Continue will allow the package to complete the if..else lines

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).

<!-- The following section can be removed if the package has not been migrated from another location -->
## Original Location
- [Original Repository](add_link_to_original_repository_location)
- [Open Issues](link_to_the_generic_location_of_open_issues) *Add the different issues underneath, and tick those that are fixed in this PR*
  - [x] Issue 1 [link](https://gist.github.com/0aadf010f605a2f7214b39c1d6da8bde)
  - [ ] Issue 2 Link
- [ ] *Include the link to the opened PR that removes the package from the original location*
- [ ] The [migration guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/wiki/Package-migration-process) have been followed
