### PR TITLE
(1password) Fixed silent installation

### DIFF
--- a/automatic/1password/1password.nuspec
+++ b/automatic/1password/1password.nuspec
@@ -26,7 +26,7 @@
     <tags>1password password keystore keys saver admin trial cross-platform</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/1password</packageSourceUrl>
     <dependencies>
-      <dependency id="dotnet4.6.2" version="4.6.01590.20170129" />
+      <dependency id="dotnet4.7.2" version="4.7.2.20180712" />
       <dependency id="chocolatey-core.extension" version="1.3.3" />
     </dependencies>
   </metadata>

--- a/automatic/1password/update.ps1
+++ b/automatic/1password/update.ps1
@@ -16,6 +16,7 @@ function global:au_AfterUpdate {
   . "$PSScriptRoot/update_helper.ps1"
   if ($Latest.PackageName -eq '1password4') {
     removeDependencies ".\*.nuspec"
+    addDependency ".\*.nuspec" "chocolatey-core.extension" "1.3.3"
   }
   else {
     addDependency ".\*.nuspec" 'dotnet4.7.2' '4.7.2.20180712'

--- a/automatic/1password/update.ps1
+++ b/automatic/1password/update.ps1
@@ -4,10 +4,10 @@ import-module $PSScriptRoot\..\..\extensions\chocolatey-core.extension\extension
 function global:au_SearchReplace {
   @{
     ".\tools\chocolateyInstall.ps1" = @{
-      "(?i)^(\s*url\s*=\s*)'.*'"          = "`${1}'$($Latest.URL32)'"
-      "(?i)^(\s*checksum\s*=\s*)'.*'"     = "`${1}'$($Latest.Checksum32)'"
-      "(?i)^(\s*checksumType\s*=\s*)'.*'" = "`${1}'$($Latest.ChecksumType32)'"
-      "(?i)^(\s*silentArgs\s*=\s*)'.*'"   = "`${1}'$($Latest.SilentArgs)'"
+      "(?i)^(\s*url\s*=\s*)'.*'"                = "`${1}'$($Latest.URL32)'"
+      "(?i)^(\s*checksum\s*=\s*)'.*'"           = "`${1}'$($Latest.Checksum32)'"
+      "(?i)^(\s*checksumType\s*=\s*)'.*'"       = "`${1}'$($Latest.ChecksumType32)'"
+      "(?i)^(\s*silentArgs\s*=\s*)['`"].*['`"]" = "`${1}`"$($Latest.SilentArgs)`""
     }
   }
 }

--- a/automatic/1password/update.ps1
+++ b/automatic/1password/update.ps1
@@ -1,12 +1,13 @@
-Import-Module AU
+﻿Import-Module AU
 import-module $PSScriptRoot\..\..\extensions\chocolatey-core.extension\extensions\chocolatey-core.psm1
 
 function global:au_SearchReplace {
   @{
     ".\tools\chocolateyInstall.ps1" = @{
-      "(?i)^(\s*url\s*=\s*)'.*'" = "`${1}'$($Latest.URL32)'"
-      "(?i)^(\s*checksum\s*=\s*)'.*'" = "`${1}'$($Latest.Checksum32)'"
+      "(?i)^(\s*url\s*=\s*)'.*'"          = "`${1}'$($Latest.URL32)'"
+      "(?i)^(\s*checksum\s*=\s*)'.*'"     = "`${1}'$($Latest.Checksum32)'"
       "(?i)^(\s*checksumType\s*=\s*)'.*'" = "`${1}'$($Latest.ChecksumType32)'"
+      "(?i)^(\s*silentArgs\s*=\s*)'.*'"   = "`${1}'$($Latest.SilentArgs)'"
     }
   }
 }
@@ -15,41 +16,51 @@ function global:au_AfterUpdate {
   . "$PSScriptRoot/update_helper.ps1"
   if ($Latest.PackageName -eq '1password4') {
     removeDependencies ".\*.nuspec"
-  } else {
-    addDependency ".\*.nuspec" 'dotnet4.6.2' '4.6.01590.20170129'
+  }
+  else {
+    addDependency ".\*.nuspec" 'dotnet4.7.2' '4.7.2.20180712'
+  }
+}
+
+function global:au_BeforeUpdate {
+  if ($Latest.PackageName -eq '1password4') {
+    $Latest.SilentArgs = '/VERYSILENT /NORESTART /SUPPRESSMSGBOXES /SP- /LOG=`"$($env:TEMP)\$($env:chocolateyPackageName).$($env:chocolateyPackageVersion).InnoInstall.log`"'
+  }
+  else {
+    $Latest.SilentArgs = '--silent'
   }
 }
 
 function Get-LatestOPW {
-param (
-	[string]$url,
-	[string]$kind
+  param (
+    [string]$url,
+    [string]$kind
 
-)
+  )
 
-    $url32 = Get-RedirectedUrl $url
-    $verRe = '[-]|\.exe$'
-    $version = $url32 -split $verRe | select -last 1 -skip 1
-    $version = $version -replace('\.BETA',' beta')
-    $version = Get-Version $version
-    $major = $version.ToString(1)
+  $url32 = Get-RedirectedUrl $url
+  $verRe = '[-]|\.exe$'
+  $version = $url32 -split $verRe | select -last 1 -skip 1
+  $version = $version -replace ('\.BETA', ' beta')
+  $version = Get-Version $version
+  $major = $version.ToString(1)
 
-      @{
-        URL32 = $url32
-        Version = $version.ToString()
-        PackageName = $kind
-      }
+  @{
+    URL32       = $url32
+    Version     = $version.ToString()
+    PackageName = $kind
   }
+}
 
-  $releases_opw4 = 'https://app-updates.agilebits.com/download/OPW4'
-  $kind_opw4     = '1password4'
-  $releases_opw  = 'https://app-updates.agilebits.com/download/OPW7/Y'
-  $kind_opw      = '1password'
+$releases_opw4 = 'https://app-updates.agilebits.com/download/OPW4'
+$kind_opw4 = '1password4'
+$releases_opw = 'https://app-updates.agilebits.com/download/OPW7/Y'
+$kind_opw = '1password'
 
 function global:au_GetLatest {
   $streams = [ordered] @{
     OPW4 = Get-LatestOPW -url $releases_opw4 -kind $kind_opw4
-    #OPW  = Get-LatestOPW -url $releases_opw -kind $kind_opw
+    OPW  = Get-LatestOPW -url $releases_opw -kind $kind_opw
   }
 
   return @{ Streams = $streams }

--- a/automatic/1password/update_helper.ps1
+++ b/automatic/1password/update_helper.ps1
@@ -1,4 +1,4 @@
-function LoadXml([string]$Path) {
+﻿function LoadXml([string]$Path) {
   $Path = Resolve-Path $Path
   $nu = New-Object xml
   $nu.PSBase.PreserveWhitespace = $true


### PR DESCRIPTION
## Description
The new installer requires --silent to be used for the installation of 1Password 7
Also .NET framework 4.7.2+ is now required for 1Password 7.

## Motivation and Context
Fixes #1186

## How Has this Been Tested?
Tested on chocolatey-test-environment

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).