### PR TITLE
(Script) Add script to check package conformity

### DIFF
--- a/scripts/Test-Packages-sandbox.ps1
+++ b/scripts/Test-Packages-sandbox.ps1
@@ -1,0 +1,32 @@
+md ./Error
+md ./Results
+md ./ToTest
+md ./Working
+.\Test-Sandbox.ps1 { 
+    Set-Service -Name wuauserv -StartupType Manual
+    Start-Service wuauserv
+    if(!$(choco install -y choco-nuspec-checker)) {
+        throw "Install failed"
+    }
+    choco install -y 7zip
+    $files = Get-ChildItem ./ToTest/*.nupkg
+    foreach ($file in $files) {
+        write-host "Testing $(($file.Name).replace('.nupkg',''))"
+        md "./$($file.Name)"
+        cd "./$($file.Name)"
+        7z.exe x $file
+        cd ..
+        cnc "./$($file.Name)" > "./Results/cnc.$($file.Name).txt"
+        if($(choco install -dy $(($file.Name).replace('.nupkg','')) -s "./ToTest/;https://chocolatey.org")) {
+            Write-Host "$(($file.Name).replace('.nupkg','')) working" -ForegroundColor Green
+            Move-Item $file ./Working/
+        } else {
+            Write-Debug "$(($file.Name).replace('.nupkg','')) Not working"
+            Move-Item $file ./Error/
+            $errors=$true
+        }
+    }
+    if($errors -eq $false) {
+        Stop-Computer
+    }
+}


### PR DESCRIPTION
This file combined with [Start-Sandbox.ps1](scripts/Start-Sandbox.ps1) from https://github.com/chocolatey-community/chocolatey-coreteampackages/pull/1512 can help to test packages before the test-environment

#### Here is a short explaination

* Put the nupkg files to test in the ToTest folder
* Launch Test-Packages-sandbox.ps1

#### Output
* The nuspec file will be moved into Working or Errors depending on the installation result.
* An output from [choco-nuspec-checker](https://chocolatey.org/packages/choco-nuspec-checker) will be created in the results folder for each nupkg

## How Has this Been Tested?
Tested on local Windows 10 

## Screenshot (if appropriate, usually isn't needed):
Here is a video : https://1drv.ms/v/s!ApyhW16h9QMvkRqXYvOEtRx99Jhm?e=bEfjE7

- [X] New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the code style of this repository.