### PR TITLE
(Sysinternals) Add start menu entries for GUI apps

### DIFF
--- a/automatic/sysinternals/Readme.md
+++ b/automatic/sysinternals/Readme.md
@@ -9,8 +9,9 @@ It does not contain non-troubleshooting tools like the BSOD Screen Saver or NotM
 
 - `/InstallDir` - Installation directory, by default Chocolatey tools directory.
 - `/InstallationPath` - the same as `InstallDir`
+- `/NoStartMenu` - Set to true to prevent installation of a menu item.
 
-Example: `choco install sysinternals --params "/InstallDir:C:\your\install\path"`
+Example: `choco install sysinternals --params "/InstallDir:C:\your\install\path /NoStartMenu"`
 
 ## Notes
 
@@ -18,4 +19,4 @@ Example: `choco install sysinternals --params "/InstallDir:C:\your\install\path"
 - This package by default installs to tools directory which will create shims for all applications. When you install to different directory, shims are not created but directory is added to the PATH.
 - This package downloads the nano edition of sysinternals suite when installing it on a nano server.
 - To have GUI for the tools, install [nirlauncher](https://chocolatey.org/packages/nirlauncher) package and use `/Sysinternals` package parameter.
-
+- Only tools that have a GUI are added to the start menu.

--- a/automatic/sysinternals/tools/chocolateyInstall.ps1
+++ b/automatic/sysinternals/tools/chocolateyInstall.ps1
@@ -21,6 +21,23 @@ if (Is-NanoServer) {
   $packageArgs.checksum = '7b6fab7f0ada0bc2b0748f3bc29e93846869f9dd175a0ca070bbebc07ee5de09'
  }
 
+if (-Not $pp.NoStartMenu) {
+  Write-Verbose "Creating start menu entry"
+  set-alias 7z $Env:chocolateyInstall\tools\7z.exe
+  $linkfiles = get-childitem "$installDir" -include "*.exe" -recurse
+  $startmenufolder = "$($env:ProgramData)\Microsoft\Windows\Start Menu\Programs\Sysinternals Suite"
+  Add-Content "$toolsPath\chocoUninstall.ps1" -Value "Remove-Item `"$($startmenufolder)`" -Recurse -Force -ea ignore"
+  # This will create a Link for all gui application and add a line chocoUninstall.ps1 to remove it on uninstall
+  foreach ($file in $linkfiles) {
+    $guiinf = 7z l $file
+    # Only link gui applications
+    if( -Not ( $guiinf -match "^Subsystem = Windows GUI" ) ) { continue }
+    Write-Verbose "Creating Start Menu enty for $($file.BaseName)"
+    $newlink ="$($startmenufolder)\$($file.BaseName).lnk"
+    Install-ChocolateyShortcut -shortcutFilePath $newlink -targetPath "$file"
+  }
+}
+
 $old_path = 'c:\sysinternals'
 if ((Test-Path $old_path) -and ($installDir -ne $old_path)) {
     Write-Warning "Clean up older versions of this install at c:\sysinternals"

--- a/automatic/sysinternals/tools/chocolateyUninstall.ps1
+++ b/automatic/sysinternals/tools/chocolateyUninstall.ps1
@@ -1,0 +1,6 @@
+
+$toolsPath = Split-Path $MyInvocation.MyCommand.Definition
+
+if (Test-Path $toolsPath\chocoUninstall.ps1) {
+    . $toolsPath\chocoUninstall.ps1
+}


### PR DESCRIPTION
## Description
Add start menu entries for the Gui-App of Sysinternals. They are added to a `Sysinternals Suite` folder.
By passing `/NoStartMenu` no entries are created.
They folder is removed upon uninstalling.

## Motivation and Context
This will allow starting the apps from the start menu, as well as ease starting them using Windows-Key+Typing

## How Has this Been Tested?
Installed and uninstalled.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

