### PR TITLE
(Calibre) Update AU script for 5.x releases

### DIFF
--- a/automatic/calibre/update.ps1
+++ b/automatic/calibre/update.ps1
@@ -1,7 +1,7 @@
 import-module au
 Import-Module "$PSScriptRoot\..\..\scripts\au_extensions.psm1"
 
-$releases = 'https://download.calibre-ebook.com/4.html'
+$releases = 'https://download.calibre-ebook.com/5.html'
 
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix
@@ -33,7 +33,7 @@ function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases
 
     $versionHyperlink = $download_page.links | Select-Object -First 1
-    if ($versionHyperlink.Title -notmatch 'Release (4[\d\.]+)' ) { throw "Calibre version 3.x not found on $releases" }
+    if ($versionHyperlink.Title -notmatch 'Release (5[\d\.]+)' ) { throw "Calibre version 5.x not found on $releases" }
 
     $version = $versionHyperlink.InnerText
     $url32   = 'https://download.calibre-ebook.com/<version>/calibre-<version>.msi'


### PR DESCRIPTION
## Description

Changes the $releases page in the AU script to the page for the 5.x Calibre releases. 
Updates the version in the error checking regex to check for 5 rather than 4.

## Motivation and Context

Allows the Calibre package to update to 5.x releases

## How Has this Been Tested?

Ran the update script on my local Powershell 5 machine.
Manually checked the changes made by the update script, and tested the updated package in the test environment.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
