### PR TITLE
(ffmpeg) Fix updater with new Upstream

### DIFF
--- a/automatic/ffmpeg/tools/chocolateyInstall.ps1
+++ b/automatic/ffmpeg/tools/chocolateyInstall.ps1
@@ -4,8 +4,7 @@ $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 
 $packageArgs = @{
     PackageName    = 'ffmpeg'
-    FileFullPath   = Get-Item $toolsPath\*_x32.zip
-    FileFullPath64 = Get-Item $toolsPath\*_x64.zip    
+    FileFullPath64 = Get-Item $toolsPath\*.zip    
     Destination    = $toolsPath
 }
 

--- a/automatic/ffmpeg/update.ps1
+++ b/automatic/ffmpeg/update.ps1
@@ -1,6 +1,6 @@
 import-module au
 
-$releases = 'https://ffmpeg.zeranoe.com/builds'
+$releases = 'https://www.gyan.dev/ffmpeg/builds'
 
 function global:au_SearchReplace {
    @{
@@ -9,9 +9,7 @@ function global:au_SearchReplace {
         }
 
         ".\legal\VERIFICATION.txt" = @{
-          "(?i)(\s+x32:).*"            = "`${1} $($Latest.URL32)"
           "(?i)(\s+x64:).*"            = "`${1} $($Latest.URL64)"
-          "(?i)(checksum32:).*"        = "`${1} $($Latest.Checksum32)"
           "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum64)"
           "(?i)(Get-RemoteChecksum).*" = "`${1} $($Latest.URL64)"
         }
@@ -21,16 +19,12 @@ function global:au_SearchReplace {
 function global:au_BeforeUpdate { Get-RemoteFiles -Purge }
 
 function global:au_GetLatest {
-  $urlPre = "$releases/win32/static/"
-  $download_page = Invoke-WebRequest -Uri "$releases/win32/static/" -UseBasicParsing -Header @{ Referer = $releases }
-  $version       = $download_page.links | ? href -match '\.(zip|7z)$' | % { $_.href -split '-' | select -Index 1} | ? { $__=$null; [version]::TryParse($_, [ref] $__) } | sort -desc | select -First 1
-  $url32         = $download_page.links | ? href -match "\-${version}\-" | % href | Select -Last 1 | % { $urlPre + $_ }
+  $urlPre = "$releases/packages/"
+  $download_page = Invoke-WebRequest -Uri "$releases/packages/" -UseBasicParsing -Header @{ Referer = $releases }
+  $version       = $download_page.links | ? href -match 'essentials_build\.(zip|7z)$' | % { $_.href -split '-' | select -Index 1} | ? { $__=$null; [version]::TryParse($_, [ref] $__) } | sort -desc | select -First 1
+  $url64         = $download_page.links | ? href -match "\-${version}\-.*\-essentials_build.*"  | % href | Select -Last 1 | % { $urlPre + $_ }
 
-  $urlPre    = $urlPre -replace 'win32','win64'
-  $download_page = Invoke-WebRequest -Uri "$releases/win64/static/" -UseBasicParsing -Header @{ Referer = $releases }
-  $url64         = $download_page.links | ? href -match "\-${version}\-" | % href | Select -Last 1 | % { $urlPre + $_ }
-
-  @{ URL32 = $url32; URL64=$url64; Version = $version }
+  @{ URL64=$url64; Version = $version }
 }
 
 update -ChecksumFor none


### PR DESCRIPTION
## Description
- Currently, FFmpeg upstream https://ffmpeg.zeranoe.com/builds has gone down forever. #1552 
- Now, the updater looks for the build from https://www.gyan.dev/ffmpeg/builds/ instead of previous upstream. I got it found on its official website https://ffmpeg.org/download.html#build-windows . Also, there is a problem. It looks like they provide x64 bit zip files. Another alternative was https://github.com/BtbN/FFmpeg-Builds/releases but the problem there is that it provides daily builds and package needs to updated daily. Not worth it.

## Motivation and Context
Without it `ffmpeg` will never be upgraded.
Fixes #1552 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
