### PR TITLE
(mpc-hc-clsid2) AU Fix for Stable Releases

### DIFF
--- a/automatic/mpc-hc-clsid2/update.ps1
+++ b/automatic/mpc-hc-clsid2/update.ps1
@@ -27,8 +27,7 @@ function global:au_GetLatest {
   $re = 'x86\.exe$'
   $url32 = $download_page.Links | ? href -match $re | select -first 1 -expand href | % { 'https://github.com' + $_ }
 
-  $re = 'x64\.exe$'
-  $url64 = $download_page.links | ? href -match $re | select -first 1 -expand href | % { 'https://github.com' + $_ }
+  $url64 = $url32 -replace "x86","x64"
 
   $verRe = 'MPC-HC\.|\.x(86|64)'
   $version32 = $url32 -split "$verRe" | select -first 1 -skip 1

--- a/automatic/mpc-hc-clsid2/update.ps1
+++ b/automatic/mpc-hc-clsid2/update.ps1
@@ -29,7 +29,7 @@ function global:au_GetLatest {
   $versionHtml = $releasesPage.Links | ? title -match $re | select -first 1
   $version = $versionHtml.title
 
-  $download_page = Invoke-WebRequest -Uri "$($releases)/tag/$($version)"
+  $download_page = Invoke-WebRequest -Uri "$($releases)/tag/$($version)" -UseBasicParsing
   $re = 'x64\.exe$'
   $url64 = $download_page.links | ? href -match $re | select -first 1 -expand href | % { 'https://github.com' + $_ }
 

--- a/automatic/mpc-hc-clsid2/update.ps1
+++ b/automatic/mpc-hc-clsid2/update.ps1
@@ -36,7 +36,6 @@ function global:au_GetLatest {
   $re = 'x86\.exe$'
   $url32 = $download_page.Links | ? href -match $re | select -first 1 -expand href | % { 'https://github.com' + $_ }
 
-  $url32 =
   @{
     URL32        = $url32
     URL64        = $url64


### PR DESCRIPTION
## Description
I have made it so that MPC-HC-CLSID2 will let the AU get the latest stable releases without outputting an error.

## Motivation and Context
This fixes the AU giving an error every time it runs because MPC-HC-CLSID2 does not have conventional update names.

## How Has This Been Tested?
I have run it locally along with a private PR to ensure the bot will run correctly. They both were successful.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).