### PR TITLE
(youtube-dl) Switch to current GitLab working repo in nuspec package

### DIFF
--- a/automatic/youtube-dl/youtube-dl.nuspec
+++ b/automatic/youtube-dl/youtube-dl.nuspec
@@ -7,11 +7,10 @@
     <title>youtube-dl</title>
     <owners>chocolatey-community</owners>
     <authors>Ricardo Garcia and others</authors>
-    <licenseUrl>http://web.archive.org/web/20200916114358/https://github.com/ytdl-org/youtube-dl/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://gitlab.com/dstftw/youtube-dl/-/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://youtube-dl.org/</projectUrl>
-    <projectSourceUrl>https://github.com/ytdl-org/youtube-dl</projectSourceUrl>
-    <bugTrackerUrl>https://github.com/ytdl-org/youtube-dl/issues</bugTrackerUrl>
-    <docsUrl>http://web.archive.org/web/20200815214757if_/https://raw.githubusercontent.com/ytdl-org/youtube-dl/master/README.md</docsUrl>
+    <projectSourceUrl>https://gitlab.com/dstftw/youtube-dl</projectSourceUrl>
+    <docsUrl>https://gitlab.com/dstftw/youtube-dl/-/blob/master/README.md</docsUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description><![CDATA[
 youtube-dl is a small command-line program to download videos from YouTube.com and a few more sites. It is written in Python and it's not platform specific. It should work in your Unix box, in Windows or in Mac OS X. It is released to the public domain, which means you can modify it, redistribute it or use it however you like.
@@ -23,7 +22,7 @@ youtube-dl is a small command-line program to download videos from YouTube.com a
 ]]></description>
     <summary>youtube-dl is a small command-line program to download videos from YouTube.com and a few more sites.</summary>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@a42da86c9cc480a5f3f23677e0d73d88416a3b3c/icons/y-dl.svg</iconUrl>
-    <releaseNotes>http://web.archive.org/web/20200930200424/https://github.com/ytdl-org/youtube-dl/blob/master/ChangeLog</releaseNotes>
+    <releaseNotes>https://gitlab.com/dstftw/youtube-dl/-/blob/master/ChangeLog</releaseNotes>
     <copyright>Public domain</copyright>
     <language>en-US</language>
     <tags>youtube-dl cli foss cross-platform video multimedia ffmpeg youtube download</tags>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
Fixes to package URLs to point to main dev's working Git repo, to fix InvalidUrlProvided errors at validation.

## Motivation and Context
Fixes errors in nuspec package caused by currently offline GitHub URLs. https://chocolatey.org/packages/youtube-dl/2020.11.12

## How Has this Been Tested?
URLs tested.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this repository.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [X] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).