### PR TITLE
(Keepassxc) switch to install-chocolateyinstallpackage

### DIFF
--- a/automatic/keepassxc/tools/chocolateyInstall.ps1
+++ b/automatic/keepassxc/tools/chocolateyInstall.ps1
@@ -3,22 +3,17 @@
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
-  packageName    = 'keepassxc'
+  packageName    = $env:ChocolateyPackageName
   softwareName   = 'KeePassXC'
   fileType       = 'msi'
   file           = "$toolsDir\KeePassXC-2.6.2-Win32.msi"
   file64         = "$toolsDir\KeePassXC-2.6.2-Win64.msi"
-  checksum       = '8864F3E19DEBCBE22997EAFB3B32F7B07CA355DFC8BF735667A46BBF0AD68B6D'
-  checksumType   = 'sha256'
-  checksum64     = '3B95A44ECAC25DF638323C7B75789EB14497DB50D25B67C90B170C2BA4B5FC85'
-  checksumType64 = 'sha256'
-
   # MSI
   silentArgs     = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
   validExitCodes = @(0, 3010, 1641)
 }
 
-Install-ChocolateyPackage @packageArgs
+Install-ChocolateyInstallPackage @packageArgs
 
 # Lets remove the installer and ignore files as there is no more need for them
 Get-ChildItem $toolsDir\*.$packageArgs['fileType'] | ForEach-Object { Remove-Item $_ -ea 0; if (Test-Path $_) { Set-Content "$_.ignore" '' } }

--- a/automatic/keepassxc/update.ps1
+++ b/automatic/keepassxc/update.ps1
@@ -26,8 +26,6 @@ function global:au_SearchReplace {
     ".\tools\chocolateyInstall.ps1" = @{
       "(?i)(^\s*file\s*=\s*`"[$]toolsDir\\).*"   = "`${1}$($Latest.FileName32)`""
       "(?i)(^\s*file64\s*=\s*`"[$]toolsDir\\).*" = "`${1}$($Latest.FileName64)`""
-      "(?i)(^\s*checksum\s*=\s*)'(.*)'"          = "`${1}'$($Latest.Checksum32)'"
-      "(?i)(^\s*checksum64\s*=\s*)'(.*)'"        = "`${1}'$($Latest.Checksum64)'"
     }
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description

Switches Keepassxc to `Install-ChocolateyInstallPackage` from `Install-ChocolateyPackage`

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

Install-ChocolateyPackage "downloads" the package before install, creating an extra copy in temp and taking longer on install.
Install-ChocolateyInstallPackage is more efficient as it installs directly, 

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

Tested on a Windows 10 machine, and in the test environment.
AU update script adjusted according to the changes and tested.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).