### PR TITLE
(protoc) fix the staled version problem

### DIFF
--- a/automatic/protoc/protoc.nuspec
+++ b/automatic/protoc/protoc.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <!-- IconUrl: Skip check -->
     <id>protoc</id>
-    <version>4.0.0-rc-2</version>
+    <version>0.0.0</version>
     <title>Protocol Buffers</title>
     <authors>Google</authors>
     <owners>chocolatey-community, keen, jordigg, drel</owners>

--- a/automatic/protoc/tools/chocolateyBeforeModify.ps1
+++ b/automatic/protoc/tools/chocolateyBeforeModify.ps1
@@ -1,3 +1,0 @@
-﻿Write-Host "Removing protoc shim before upgrading/uninstalling..."
-
-Uninstall-BinFile "protoc" -path "$(Split-Path -parent $MyInvocation.MyCommand.Definition)\bin\protoc.exe"

--- a/automatic/protoc/tools/chocolateyinstall.ps1
+++ b/automatic/protoc/tools/chocolateyinstall.ps1
@@ -10,5 +10,3 @@ $packageArgs = @{
 }
 Get-ChocolateyUnzip @packageArgs
 Remove-Item $toolsPath\*.zip -ea 0
-
-Install-BinFile 'protoc' "$toolsPath\bin\protoc.exe"

--- a/automatic/protoc/update.ps1
+++ b/automatic/protoc/update.ps1
@@ -27,8 +27,8 @@ function global:au_GetLatest {
 
 
     $download_page = Invoke-WebRequest -Uri "$releases" -UseBasicParsing
-    $url32 = $download_page.links | ? href -match '/protoc-(.+)-win32\.zip$' | % href | select -First 1
-    $url64 = $download_page.links | ? href -match '/protoc-(.+)-win64\.zip$' | % href | select -First 1
+    $url32 = $download_page.links | ? href -match '/protoc-(\d+\.\d+\.\d+)-win32\.zip$' | % href | select -First 1
+    $url64 = $download_page.links | ? href -match '/protoc-(\d+\.\d+\.\d+)-win64\.zip$' | % href | select -First 1
 
     $version = $Matches[1]
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->
Fixed the google protocol buffer library staled automatic update problem (issue #1588). Also removed explicit shimming generation and removal as @majkinetor and @AdmiringWorm suggested in pull request #1345.

## Description
<!-- Describe your changes in detail -->
1. I did not use streams, because, compared to the chromium package, this one relies on the github release page and the prerelease version is not guaranteed to even exist within the first few pages, and I feel like it might be tricky to handle these "nullable" values in streams. As a compromise, I am now limiting the download link regex match to search for stable versions only.
2. I removed the call to `Install-BinFile` and the script `chocolateyBeforeModify.ps1` as suggested in pull request #1345.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->
Fixes issue #1588.

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
Tested locally.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

