### PR TITLE
(Youtube-dl) Revert URLs back to official repo now that it is back up.

### DIFF
--- a/automatic/youtube-dl/youtube-dl.nuspec
+++ b/automatic/youtube-dl/youtube-dl.nuspec
@@ -7,10 +7,10 @@
     <title>youtube-dl</title>
     <owners>chocolatey-community</owners>
     <authors>Ricardo Garcia and others</authors>
-    <licenseUrl>https://gitlab.com/dstftw/youtube-dl/-/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/ytdl-org/youtube-dl/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://youtube-dl.org/</projectUrl>
-    <projectSourceUrl>https://gitlab.com/dstftw/youtube-dl</projectSourceUrl>
-    <docsUrl>https://gitlab.com/dstftw/youtube-dl/-/blob/master/README.md</docsUrl>
+    <projectSourceUrl>https://github.com/ytdl-org/youtube-dl</projectSourceUrl>
+    <docsUrl>https://github.com/ytdl-org/youtube-dl/blob/master/README.md</docsUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description><![CDATA[
 youtube-dl is a small command-line program to download videos from YouTube.com and a few more sites. It is written in Python and it's not platform specific. It should work in your Unix box, in Windows or in Mac OS X. It is released to the public domain, which means you can modify it, redistribute it or use it however you like.
@@ -22,7 +22,7 @@ youtube-dl is a small command-line program to download videos from YouTube.com a
 ]]></description>
     <summary>youtube-dl is a small command-line program to download videos from YouTube.com and a few more sites.</summary>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@a42da86c9cc480a5f3f23677e0d73d88416a3b3c/icons/y-dl.svg</iconUrl>
-    <releaseNotes>https://gitlab.com/dstftw/youtube-dl/-/blob/master/ChangeLog</releaseNotes>
+    <releaseNotes>https://github.com/ytdl-org/youtube-dl/blob/master/ChangeLog</releaseNotes>
     <copyright>Public domain</copyright>
     <language>en-US</language>
     <tags>youtube-dl cli foss cross-platform video multimedia ffmpeg youtube download</tags>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Changes various URLs in the nuspec back to the youtube-dl official yt-dl repository links. 
The repository was taken down in response to a DMCA notice but has been put back up. 
The URLs were changed in #1562 to point to a temporary mirror of the repository, but that mirror has been taken down.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

Some of the current URLs are broken because they pointed to a temporary mirror which has been taken down.
So the package is not passing the validator

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

Ran through CNC, installed locally and in the chocolatey test env.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
