### PR TITLE
(autohotkey.portable) Fix if condition and typo

### DIFF
--- a/automatic/autohotkey.portable/tools/chocolateyInstall.ps1
+++ b/automatic/autohotkey.portable/tools/chocolateyInstall.ps1
@@ -15,12 +15,12 @@ Remove-Item $zip_path -ea 0
 
 Write-Host "Removing ANSI-32 version"
 Remove-Item "$toolsPath/AutoHotkeyA32.exe" -ea 0
-if (Get-OSArchitectureWidth 64 -and ($Env:chocolateyForceX86 -ne 'true')) {
+if ((Get-OSArchitectureWidth 64) -and ($Env:chocolateyForceX86 -ne 'true')) {
     Write-Verbose "Removing UNICODE-32 version"
     Remove-Item "$toolsPath/AutoHotkeyU32.exe" -ea 0
     Move-Item "$toolsPath/AutoHotkeyU64.exe" "$toolsPath/AutoHotkey.exe" -Force
 } else {
-    Write-Verbose "Removing UNICODE-64  version"
+    Write-Verbose "Removing UNICODE-64 version"
     Remove-Item "$toolsPath/AutoHotkeyU64.exe" -ea 0
     Move-Item "$toolsPath/AutoHotkeyU32.exe" "$toolsPath/AutoHotkey.exe" -Force
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->
This commit encloses `Get-OSArchitectureWidth 64` with parentheses and removes an unnecessary space.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->
This commit ensures that the 32-bit version of AutoHotkey v2 can be installed on an x64 environment.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

