### PR TITLE
FIX: Thunderbird Dev Docs URL was changed

### DIFF
--- a/automatic/thunderbird/thunderbird.nuspec
+++ b/automatic/thunderbird/thunderbird.nuspec
@@ -10,7 +10,7 @@
     <licenseUrl>https://www.mozilla.org/en-US/about/legal/terms/thunderbird/</licenseUrl>
     <projectUrl>https://www.mozilla.org/en/thunderbird/</projectUrl>
     <projectSourceUrl>https://hg.mozilla.org/comm-central</projectSourceUrl>
-    <docsUrl>https://developer.mozilla.org/en-US/Thunderbird</docsUrl>
+    <docsUrl>https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird</docsUrl>
     <bugTrackerUrl>https://bugzilla.mozilla.org/</bugTrackerUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/thunderbird.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
Verification fix - thunderbird package has been stuck in "waiting for maintainer" for alsmost two weeks

## Description
The URL to the thunderbird developer docs has changed.

## Motivation and Context
With this change the thunderbird package should build and verify again

## How Has this Been Tested?
Tested by opening the new url in a webbrowser, should have no influence on any part of the actual installation.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

THere's no actual code change here - only one changed URL in the spec file for thunderbird.

<!-- The following section can be removed if the package has not been migrated from another location -->
## Original Location
- [Original Repository](add_link_to_original_repository_location)
- [Open Issues](link_to_the_generic_location_of_open_issues) *Add the different issues underneath, and tick those that are fixed in this PR*
  - [ ] Issue 1 link
  - [ ] Issue 2 Link
- [ ] *Include the link to the opened PR that removes the package from the original location*
- [ ] The [migration guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/wiki/Package-migration-process) have been followed
