### PR TITLE
(no package) Fix links to Chocolatey docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,9 @@ The following sections present complete set of guideliness, please read them car
 
 ### 1.1.1 Conform to guidelines
 
-Conform with the [official package creation guidelines](https://chocolatey.org/docs/create-packages) and take a look at [quick start guide](https://chocolatey.org/docs/CreatePackagesQuickStart) on how to create packages.
+Conform with the [official package creation guidelines](https://docs.chocolatey.org/en-us/create/create-packages) and take a look at [quick start guide](https://docs.chocolatey.org/en-us/create/create-packages-quick-start) on how to create packages.
 
-You should also know how to [deprecate a package](https://chocolatey.org/docs/how-to-deprecate-a-chocolatey-package).
+You should also know how to [deprecate a package](https://docs.chocolatey.org/en-us/community-repository/maintainers/deprecate-a-chocolatey-package).
 
 ### 1.1.2 Manual or automatic
 
@@ -59,7 +59,7 @@ For software that explicitly doesn't allow redistribution via adequate license t
 - signed letter
 - PDF of an email chain granting that permission
 
-As an example take a look at the [activepresenter](https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/activepresenter/legal) package. Embeding non-allowed binaries may have [legal repercussions](https://chocolatey.org/docs/legal).
+As an example take a look at the [activepresenter](https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/activepresenter/legal) package. Embeding non-allowed binaries may have [legal repercussions](https://docs.chocolatey.org/en-us/information/legal).
 
 **NOTE**: 200MB is the maximum size of the package. Larger tools must be downloaded from a vendor site or mirror.
 
@@ -198,7 +198,7 @@ Do not create brittle scripts that work only when user doesn't interfer. All scr
 
 ### 2.1 Encoding
 
-Always __use UTF-8 without BOM__ for the `*.nuspec` and __UTF-8 with BOM__ for the `*.ps1` files. See [character encodings](https://chocolatey.org/docs/create-packages#character-encoding).
+Always __use UTF-8 without BOM__ for the `*.nuspec` and __UTF-8 with BOM__ for the `*.ps1` files. See [character encodings](https://docs.chocolatey.org/en-us/create/create-packages#character-encoding).
 
 ### 2.2 Code style
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ### Description
 
-This repository contains chocolatey packages, most of which are [automatic](https://chocolatey.org/docs/automatic-packages).
+This repository contains chocolatey packages, most of which are [automatic](https://docs.chocolatey.org/en-us/create/automatic-packages).
 
 These packages are managed and maintained by the Chocolatey community package maintainers core team, and also supported by you (the community)! To get a package added here, the official [Chocolatey Community Account](http://chocolatey.org/profiles/chocolatey-community) has to have push access to the package on [chocolatey.org](http://chocolatey.org).
 


### PR DESCRIPTION
## Description
Fix links to Chocolatey docs

## Motivation and Context
The Contributing and Readme files had a broken link (to the Quick Start guide), I've fixed that and also updated the other links to Chocolatey docs in those two files to avoid an unnecessary redirect. (The documentation has moved from chocolatey.org/docs to docs.chocolatey.org)

## How Has this Been Tested?
Links tested manually

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment. (No package was modified.)
- [ ] The changes only affect a single package (not including meta package). (Changes do not affect any package.)