### PR TITLE
(mkdocs) change minimum python version to 3.5

### DIFF
--- a/automatic/mkdocs/mkdocs.nuspec
+++ b/automatic/mkdocs/mkdocs.nuspec
@@ -31,7 +31,7 @@ MkDocs is a fast, simple and downright gorgeous static site generator that's gea
     <releaseNotes>http://www.mkdocs.org/about/release-notes/</releaseNotes>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.3.3" />
-      <dependency id="Python" version="2.6" />
+      <dependency id="Python" version="3.5" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
## Description
see meta section in https://pypi.org/project/mkdocs/, mkdocs doesn't work with `python<=3.5`.

## Motivation and Context
If a user has only python2 installed it will create an error because mkdocs support only `Python >=3.5`. This PR changes the minimum to 3.5.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

