### PR TITLE
(freecad) adds support for new installer name

### DIFF
--- a/automatic/freecad/update_helper.ps1
+++ b/automatic/freecad/update_helper.ps1
@@ -9,7 +9,7 @@ param(
   $try = (($download_page.Links | ? href -match "CAD\-|\.[\dA-Z]+\-WIN" | select -First 1 -expand href).Split("/")[-1]).Split(".")[-1]
   $ext = @{$true='7z';$false='exe'}[( $kind -match 'dev' ) -or ( $portable -match 'portable' )]
   $re32 = "(WIN)\-x32\-($portable)\.$ext";
-  $re64 =  @{$true="(WIN|Win)\-(Conda|x64)(\-|_)$portable+(\.$ext)$";$false="(WIN)\-x64\-($portable)\.$ext$"}[( $kind -match 'dev' )]
+  $re64 =  @{$true="(WIN|Win)\-(Conda|x64)(\-|_)$portable+(\.$ext)$";$false="(WIN)\-x64\-($portable)(\-[0-9])?\.$ext$"}[( $kind -match 'dev' )]
   $url32 = $download_page.Links | ? href -match $re32 | select -first 1 -expand href
   $url64 = $download_page.Links | ? href -match $re64 | select -first 1 -expand href
   $checking = (($url64.Split('\/'))[-1]) -replace($re64,'') -replace('\-','.'); $version = ( Get-Version $checking ).Version


### PR DESCRIPTION
## Description
I've changed the regex for getting 64bit executable filename from github releases.
`... (\-[0-9])? ...`

## Motivation and Context
It seems that the freecad team decided to append `-1` to the filename of the executable.

## How Has this Been Tested?
I've tested this on my local windows 10 (20H2) pc.

```
PS E:\git\chocolatey-coreteampackages\automatic\freecad> .\update.ps1
freecad - checking updates using au version 2020.11.21

*** Stream: portable ***
URL check
  https://github.com/FreeCAD/FreeCAD/releases/download/0.19.1/FreeCAD-0.19.1.a88db11-WIN-x64-portable-1.7z
  https://github.com/FreeCAD/FreeCAD/releases/download/0.18.4/FreeCAD-0.18.4.980bf90-WIN-x32-portable.7z
nuspec version: 0.19.1
remote version: 0.19.1
No new version found

*** Stream: stable ***
URL check
  https://github.com/FreeCAD/FreeCAD/releases/download/0.19.1/FreeCAD-0.19.1.a88db11-WIN-x64-installer-1.exe
  https://github.com/FreeCAD/FreeCAD/releases/download/0.18.4/FreeCAD-0.18.4.980bf90-WIN-x32-installer.exe
nuspec version: 0.19.1
remote version: 0.19.1
No new version found

*** Stream: dev ***
URL check
  https://github.com/FreeCAD/FreeCAD/releases/download/0.19.1/FreeCAD_0.19.24276-Win-Conda_vc14.x-x86_64.7z
nuspec version: 0.19.0.24276-dev
remote version: 0.19.0.24276-dev
No new version found


Path          : E:\git\chocolatey-coreteampackages\automatic\freecad
Name          : freecad
Updated       : False
Pushed        : False
RemoteVersion : 0.19.0.24276-dev
NuspecVersion : 0.19.0.24276-dev
Result        : {freecad - checking updates using au version 2020.11.21, , *** Stream: portable ***, URL check...}
Error         :
NuspecPath    : E:\git\chocolatey-coreteampackages\automatic\freecad\freecad.nuspec
NuspecXml     : #document
Ignored       : False
IgnoreMessage :
StreamsPath   : E:\git\chocolatey-coreteampackages\automatic\freecad\freecad.json
Streams       : {portable, stable, dev}
```

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).