### PR TITLE
(mkdocs) Find correct python executable

### DIFF
--- a/automatic/mkdocs/tools/ChocolateyInstall.ps1
+++ b/automatic/mkdocs/tools/ChocolateyInstall.ps1
@@ -13,10 +13,10 @@ function FindPython {
     $allowed_python_versions
   )
   # see https://www.python.org/dev/peps/pep-0514/#structure
-  # we are querying machine regsitry only because chocolatey
+  # we are querying machine registry only because chocolatey
   # installs python in admin mode only.
-  $avaiable_installation = Get-ChildItem -Path Registry::HKEY_LOCAL_MACHINE\Software\Python\PythonCore | Select-Object Name
-  foreach ($install in $avaiable_installation) {
+  $available_installation = Get-ChildItem -Path HKLM:\Software\Python\PythonCore | Select-Object Name
+  foreach ($install in $available_installation) {
     $name_install = $install.Name
     $install_version = ($name_install -split '\\')[-1]
     if ($allowed_python_versions.Contains($install_version)) {

--- a/automatic/mkdocs/tools/ChocolateyInstall.ps1
+++ b/automatic/mkdocs/tools/ChocolateyInstall.ps1
@@ -1,5 +1,5 @@
 ﻿Update-SessionEnvironment
-
+$allowed_python_versions = @('3.9', '3.8', '3.7', '3.6', '3.5') # sync with nuspec
 $version = '1.1.2'
 
 $proxy = Get-EffectiveProxy
@@ -7,4 +7,28 @@ if ($proxy) {
   Write-Host "Setting CLI proxy: $proxy"
   $env:http_proxy = $env:https_proxy = $proxy
 }
-python -m pip install mkdocs==$version
+
+function FindPython {
+  param(
+    $allowed_python_versions
+  )
+  # see https://www.python.org/dev/peps/pep-0514/#structure
+  # we are querying machine regsitry only because chocolatey
+  # installs python in admin mode only.
+  $avaiable_installation = Get-ChildItem -Path Registry::HKEY_LOCAL_MACHINE\Software\Python\PythonCore | Select-Object Name
+  foreach ($install in $avaiable_installation) {
+    $name_install = $install.Name
+    $install_version = ($name_install -split '\\')[-1]
+    if ($allowed_python_versions.Contains($install_version)) {
+      Write-Host "Found Python Version from Registry $install_version" -ForegroundColor Yellow
+      $python_executable = Get-ItemProperty -Path "Registry::$name_install\InstallPath" | Select-Object ExecutablePath
+      Write-Host "Found Install Path from Registry $($python_executable.ExecutablePath)" -ForegroundColor Yellow
+      return $python_executable.ExecutablePath
+    }
+  }
+}
+
+$python = FindPython $allowed_python_versions
+Write-Host "Found python at '$python'. Using it."
+& "$python" -m ensurepip # make sure pip exists
+& "$python" -m pip install mkdocs==$version

--- a/automatic/mkdocs/update.ps1
+++ b/automatic/mkdocs/update.ps1
@@ -5,9 +5,9 @@ $releases = 'https://pypi.python.org/pypi/mkdocs'
 function global:au_SearchReplace {
     @{
         'tools\ChocolateyInstall.ps1' = @{
-            "(^[$]version\s*=\s*)('.*')" = "`$1'$($Latest.Version)'"
+            "(^[$]version\s*=\s*)('.*')" = "`$1'$($Latest.PyPIVersion)'"
         }
-     }
+    }
 }
 
 function global:au_GetLatest {
@@ -17,7 +17,7 @@ function global:au_GetLatest {
     $url = $download_page.links | ? href -match $re | select -first 1 -expand href
     $version = $url -split '\/' | select -last 1 -skip 1
 
-    return @{ Version = $version }
+    return @{ Version = $version; PyPIVersion = $version }
 }
 
 update -ChecksumFor none


### PR DESCRIPTION
## Description
Find the correct python executable by querying the registry.
Currently, the package just chooses the first `python.exe` which it seems. The `python.exe` could be from a venv(virtual environment) and could be problematic. It should query registry as specified in https://www.python.org/dev/peps/pep-0514 and then find the `python.exe` which is originally installed from an Installer and use the `python.exe` from there.

## Motivation and Context
Fixes https://github.com/chocolatey-community/chocolatey-coreteampackages/issues/1623
Prevent installing mkdocs on a Virtual environment(venv).

## How Has this Been Tested?

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
