### PR TITLE
(vcredist2008, vcredist2010) Update metadata and prevent double install of 32-bit version

### DIFF
--- a/manual/vcredist2008/tools/chocolateyInstall.ps1
+++ b/manual/vcredist2008/tools/chocolateyInstall.ps1
@@ -14,7 +14,7 @@ Install-ChocolateyPackage @params
 
 # Install both 32bit and 64bit on a 64bit OS
 # If a program is compiled as x86 and the 32bit version of vcredist isn't installed, then the program would fail to start.
-if (Get-ProcessorBits 64) {
+if (Get-ProcessorBits 64 -and ($env:chocolateyForceX86 -ne $true)) {
   $originalChocolateyForceX86 = $Env:chocolateyForceX86
   $Env:chocolateyForceX86 = $true
   Install-ChocolateyPackage @params

--- a/manual/vcredist2008/vcredist2008.nuspec
+++ b/manual/vcredist2008/vcredist2008.nuspec
@@ -1,32 +1,29 @@
 <?xml version="1.0"?>
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
-
 <!-- IconUrl: Skip check -->
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
-    <id>vcredist2008</id>
     <version>0.0</version>
-    <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/manual/vcredist2008</packageSourceUrl>
-    <owners>chocolatey-community, dtgm</owners>
-    <title>Microsoft Visual C++ 2008 SP1 Redistributable Package</title>
+    <packageSourceUrl>https://github.com/chocolatey/chocolatey-coreteampackages/tree/master/manual/vcredist2010</packageSourceUrl>
     <authors>Microsoft</authors>
-    <projectUrl>https://www.microsoft.com/download/details.aspx?id=26368</projectUrl>
-    <copyright>https://www.microsoft.com/en-us/legal/intellectualproperty/copyright</copyright>
+    <owners>chocolatey-community, dtgm</owners>
     <licenseUrl>http://msdn.microsoft.com/en-US/cc300389.aspx</licenseUrl>
+    <projectUrl>https://www.microsoft.com/en-us/download/details.aspx?id=26368</projectUrl>
+    <id>vcredist2008</id>
+    <title>Microsoft Visual C++ 2008 SP1 Redistributable Package</title>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <docsUrl>https://msdn.microsoft.com/library/jj620919.aspx</docsUrl>
-    <bugTrackerUrl>https://visualstudio.uservoice.com/forums/121579-visual-studio</bugTrackerUrl>
-    <tags>microsoft visual c++ redistributable 2008 admin</tags>
-    <summary>Runtime components of C Runtime (CRT), Standard C++, ATL, MFC, OpenMP and MSDIA libraries. For libraries that support side-by-side deployment model (CRT, SCL, ATL, MFC, OpenMP)</summary>
     <description>
 AUTO Imported from README.md
 </description>
+    <summary>Runtime components of C Runtime (CRT), Standard C++, ATL, MFC, OpenMP and MSDIA libraries. For libraries that support side-by-side deployment model (CRT, SCL, ATL, MFC, OpenMP)</summary>
     <releaseNotes>
     - MFC Security Update: A security issue has been identified leading to MFC application vulnerability in DLL planting due to MFC not specifying the full path to system/localization DLLs. You can protect your computer by installing this update from Microsoft. After you install this item, you may have to restart.
     - KB Article: [KB2538241](http://support.microsoft.com/kb/2538241)
     - Security bulletin: [MS11-025](http://technet.microsoft.com/security/Bulletin/MS11-025)
     - Microsoft published: 6/7/2011
     </releaseNotes>
+    <copyright>https://www.microsoft.com/en-us/legal/intellectualproperty/copyright</copyright>
+    <tags>microsoft visual c++ redistributable 2008 studio vcredist2008 freeware admin</tags>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/manual/vcredist2010/tools/chocolateyInstall.ps1
+++ b/manual/vcredist2010/tools/chocolateyInstall.ps1
@@ -14,7 +14,7 @@ Install-ChocolateyPackage @params
 
 # Install both 32bit and 64bit on a 64bit OS
 # If a program is compiled as x86 and the 32bit version of vcredist isn't installed, then the program would fail to start.
-if (Get-ProcessorBits 64) {
+if (Get-ProcessorBits 64 -and ($env:chocolateyForceX86 -ne $true)) {
   $originalChocolateyForceX86 = $Env:chocolateyForceX86
   $Env:chocolateyForceX86 = $true
   Install-ChocolateyPackage @params

--- a/manual/vcredist2010/update.ps1
+++ b/manual/vcredist2010/update.ps1
@@ -21,7 +21,7 @@ function Get-RemoteChecksumFast([string] $Url, $Algorithm = 'sha256', $Headers) 
 function global:au_GetLatest {
   $downloadId = 26999
   $softwareVersionString = '10.0.40219.325'
-  $packageRevisionString = '02'
+  $packageRevisionString = '03'
   $packageVersion = [version]"${softwareVersionString}${packageRevisionString}"
 
   $confirmationPageUrl = "https://www.microsoft.com/en-us/download/confirmation.aspx?id=${downloadId}"

--- a/manual/vcredist2010/vcredist2010.nuspec
+++ b/manual/vcredist2010/vcredist2010.nuspec
@@ -21,7 +21,7 @@ AUTO Imported from README.md
     - Microsoft published: 8/9/2011
     </releaseNotes>
     <copyright>https://www.microsoft.com/en-us/legal/intellectualproperty/copyright</copyright>
-    <tags>visual c++ redistributable 2010 studio admin</tags>
+    <tags>microsoft visual c++ redistributable 2010 studio vcredist2010 freeware admin</tags>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
## Description

These are similar changes as requested for vcredist2005 in https://github.com/chocolatey-community/chocolatey-coreteampackages/pull/1657.

Additionally, vcredist2008 is held in moderation due to invalid bugTrackerUrl.

## How Has this Been Tested?
Manually, in a Windows Server 2019 VM.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
