### PR TITLE
(maint) Updates AppVeyor github_api_key

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ environment:
   # Github token to commit pushed packages to repository
   github_user_repo: chocolatey-community/chocolatey-coreteampackages
   github_api_key:
-    secure: 7tqvwsSAEGnwr0bYwegIsNBje1pqjdhHEoclLBQOR5HF0SOGw48Ls1OBpAimSlsf
+    secure: kp3pFdeqA90uVX4Yy2F5obA/O+P1428LrtCiuYZQYUMkSYi6yWTdmv35tOoce1k8
 
   # Gitter Integration
   gitter_webhook:


### PR DESCRIPTION
## Description
This commit updates the token being used for AppVeyor with the new PAT format.

## Motivation and Context
GitHub suggested regenerating this token to take advantage of the [new token formats](https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/). Though not breaking anything, it seemed useful for documentation.

## How Has this Been Tested?
N/A

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).