### PR TITLE
(k9s) Updated K9s update script to reflect changes to asset rename

### DIFF
--- a/automatic/k9s/tools/chocolateyinstall.ps1
+++ b/automatic/k9s/tools/chocolateyinstall.ps1
@@ -5,7 +5,7 @@ $toolsDir      = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
   PackageName    = $packageName
-  FileFullPath64 = Get-Item $toolsDir\k9s_Windows_x86_64.tar.gz
+  FileFullPath64 = Get-Item $toolsDir\k9s_*_Windows_x86_64.tar.gz
   Destination    = $toolsDir
 }
 
@@ -13,10 +13,10 @@ Get-ChocolateyUnzip @packageArgs
 
 $packageArgs2 = @{
   PackageName    = $packageName
-  FileFullPath64 = Get-Item $toolsDir\k9s_Windows_x86_64.tar
+  FileFullPath64 = Get-Item $toolsDir\k9s_*_Windows_x86_64.tar
   Destination    = $toolsDir
 }
 
 Get-ChocolateyUnzip @packageArgs2
 
-Remove-Item "$toolsDir\k9s_Windows_*.tar"
+Remove-Item "$toolsDir\k9s_*_Windows_*.tar"

--- a/automatic/k9s/update.ps1
+++ b/automatic/k9s/update.ps1
@@ -3,10 +3,8 @@ param([switch] $Force)
 
 Import-Module AU
 
-$domain   = 'https://github.com'
+$domain = 'https://github.com'
 $releases = "$domain/derailed/k9s/releases/latest"
-
-$filename64 = 'k9s_Windows_x86_64.tar.gz'
 
 function global:au_BeforeUpdate {
   Get-RemoteFiles -Purge -NoSuffix
@@ -36,8 +34,9 @@ function global:au_GetLatest {
 
   $checksumAsset = $domain + ($download_page.Links | ? href -match "checksums\.txt$" | select -first 1 -expand href)
   $checksum_page = Invoke-WebRequest -Uri $checksumAsset -UseBasicParsing
+  $filename64 = -join('k9s_v', $version, '_Windows_x86_64.tar.gz')
   $checksum64 = [regex]::Match($checksum_page, "([a-f\d]+)\s*$([regex]::Escape($filename64))").Groups[1].Value
-  
+
   return @{
     Version        = $version
     URL64          = "$domain/derailed/k9s/releases/download/v${version}/${filename64}"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->
From 0.24.10 onwards, k9s has changed the format of the asset files. See https://github.com/derailed/k9s/releases/tag/v0.24.10. Because of this, the automatic update has been failing. See https://gist.github.com/choco-bot/a14b1e5bfaf70839b338eb1ab7f8226f#k9s

This PR updates the update script to reflect the asset rename
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->
I noticed the chocolatey didn't have the latest version of k9s and on investigating I found that the error is due to the asset rename. Pre 0.24.10, the asset was called `k9s_Windows_x86_64.tar.gz`. From 0.24.10 onwards it is called `k9s_v0.24.10_Windows_x86_64.tar.gz`. Note the version name in the file. The PR solves this by generating the asset file name including the version name.

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
I have tested this locally by running `update.ps1` and it is able to fetch the latest file and update the relevant metadata. I am running Windows 10 Pro with PS version 5.1.
I have also tested on `chocolatey-test-environment` and `vagrant provision` is successful without errors.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
