### PR TITLE
fixed url and version generation in update.ps1

### DIFF
--- a/automatic/blender/update.ps1
+++ b/automatic/blender/update.ps1
@@ -25,18 +25,22 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
   $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-  $re = 'windows64\.msi\/$'
+  #regex to find download url, it should match any url that ends with a 64 bit windows msi
+  $re = '\/[^/]*windows.*64.*\.msi\/$'
   $url64 = $download_page.links | ? href -match $re | select -first 1 -expand href
 
-  $verRe = '[-]'
-  $version64 = $url64 -split "$verRe" | select -last 1 -skip 1
+  # this should get the version number based on Blender's version numbering as of 03-Jun-2020
+  $version64 = $url64 -match '\d\.\d\d\.\d+' | Foreach {$Matches[0]}
 
+  <# if block to replace a letter at end of version64 with '.1' should no longer be needed,
+  see https://wiki.blender.org/wiki/Process/LTS#Version_Communication
   if ($version64 -match '[a-z]$') {
     [char]$letter = $version64[$version64.Length - 1]
     [int]$num = $letter - [char]'a'
     $num++
     $version64 = $version64 -replace $letter,".$num"
   }
+  #>
 
   @{
     URL64 = Get-ActualUrl $url64


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->
--Resubmitted as previous pull request replaced entire file unnecessarily--
 
It looks like blender's site changed how they name their installers, breaking update.ps1, so I changed the way the url and version number are generated. Hopefully with some added future-proofing.

## Description
<!-- Describe your changes in detail -->

Changed the way the variables $re, $url64, and $version64 are created
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->
update.ps1 doesn't currently run, so the blender package will not automatically update

* fixes: Issue #1671


## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

I ran the modified update.ps1 and installed the generated package locally

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).


