### PR TITLE
(octave.portable) Update package to launch correctly with current versions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,22 +12,23 @@
 # Multiple users can be set for the same match
 
 
-*/calibre*        @gep13 @AdmiringWorm
-*/cdburnerxp*     @gep13
-*/poweriso*       @gep13
-*/rdcman*         @gep13
-*/wix*            @gep13
-*/gobby*          @AdmiringWorm
-*/gom-player*     @AdmiringWorm
-*/jubler*         @AdmiringWorm
-*/juju*           @AdmiringWorm
-*/transifex*      @AdmiringWorm
-*/waterfox*       @AdmiringWorm
-*/k9s*            @moebius87
-*/composer*       @johnstevenson
-*/krew*           @jetersen
-*/kubelogin*      @jetersen
-*/ffmpeg-full*    @VuiMuich
+*/calibre*            @gep13 @AdmiringWorm
+*/cdburnerxp*         @gep13
+*/poweriso*           @gep13
+*/rdcman*             @gep13
+*/wix*                @gep13
+*/gobby*              @AdmiringWorm
+*/gom-player*         @AdmiringWorm
+*/jubler*             @AdmiringWorm
+*/juju*               @AdmiringWorm
+*/transifex*          @AdmiringWorm
+*/waterfox*           @AdmiringWorm
+*/k9s*                @moebius87
+*/composer*           @johnstevenson
+*/krew*               @jetersen
+*/kubelogin*          @jetersen
+*/ffmpeg-full*        @VuiMuich
+*/octave.portable*    @dgalbraith
 
 # Other
 # This can be any file other that won't be matched as a package

--- a/automatic/octave.portable/README.md
+++ b/automatic/octave.portable/README.md
@@ -6,7 +6,8 @@ GNU Octave is a high-level language, primarily intended for numerical computatio
 
 Octave has extensive tools for solving common numerical linear algebra problems, finding the roots of nonlinear equations, integrating ordinary functions, manipulating polynomials, and integrating ordinary differential and differential-algebraic equations. It is easily extensible and customizable via user-defined functions written in Octave’s own language, or using dynamically loaded modules written in C++, C, Fortran, or other languages.
 
-### Features:
+## Features
+
 * Powerful mathematics-oriented syntax with built-in plotting and visualization tools
 * Drop-in compatible with many Matlab scripts
 * Octave Forge, a central location for development of packages for GNU Octave, similar to Matlab's toolboxes.

--- a/automatic/octave.portable/README.md
+++ b/automatic/octave.portable/README.md
@@ -12,3 +12,17 @@ Octave has extensive tools for solving common numerical linear algebra problems,
 * Drop-in compatible with many Matlab scripts
 * Octave Forge, a central location for development of packages for GNU Octave, similar to Matlab's toolboxes.
 * Free software, runs on GNU/Linux, macOS, BSD, and Windows
+
+## Package parameters
+
+The following package parameters can be set:
+
+* `/DesktopIcon` - Add icons for Octave to the Desktop. By default no icons are added.
+* `/StartMenu`   - Add icons for Octave to the Start Menu. By default no icons are added.
+* `/LocalUser`   - Install only for local user. By default any Octave shortcuts will be installed for all users.
+
+Example: `choco install octave.install --params "/DesktopIcon /StartMenu /LocalUser"`
+
+## Notes
+
+* The package makes Octave available through the `octave` (GUI) and  `octave-cli` (CLI) shims following installation

--- a/automatic/octave.portable/octave.portable.nuspec
+++ b/automatic/octave.portable/octave.portable.nuspec
@@ -5,16 +5,17 @@
     <id>octave.portable</id>
     <version>6.2.0</version>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/octave.portable</packageSourceUrl>
-    <owners>chocolatey-community,Andrei Bejenaru</owners>
+    <owners>chocolatey-community,dgalbraith,Andrei Bejenaru</owners>
     <title>GNU Octave (Portable)</title>
     <authors>John W. Eaton</authors>
     <projectUrl>https://www.gnu.org/software/octave</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@aa4dfe9a33e28ea4a94616e84b3648527d4fa87f/icons/octave.png</iconUrl>
-    <copyright>(c) 1998-2017 John W. Eaton</copyright>
+    <copyright>Copyright 1998-2021 John W. Eaton</copyright>
     <licenseUrl>https://www.gnu.org/software/octave/license.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://hg.savannah.gnu.org/hgweb/octave</projectSourceUrl>
     <docsUrl>https://www.gnu.org/software/octave/doc/interpreter</docsUrl>
+    <mailingListUrl>https://octave.discourse.group</mailingListUrl>
     <bugTrackerUrl>https://www.gnu.org/software/octave/bugs.html</bugTrackerUrl>
     <tags>octave matlab math numerical computations foss cross-platform</tags>
     <summary>Scientific Programming Language, largely compatible with Matlab</summary>

--- a/automatic/octave.portable/tools/chocolateyBeforeModify.ps1
+++ b/automatic/octave.portable/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,27 @@
+﻿$ErrorActionPreference = 'Stop'
+
+$gui = 'Octave.lnk'
+$cli = 'Octave CLI.lnk'
+
+$desktop         = [Environment]::GetFolderPath('Desktop')
+$commonDesktop   = [Environment]::GetFolderPath('CommonDesktopDirectory')
+$startMenu       = [Environment]::GetFolderPath('StartMenu')
+$commonStartMenu = [Environment]::GetFolderPath('CommonStartMenu')
+
+$paths = @(
+  (Join-Path $desktop $gui),
+  (Join-Path $desktop $cli),
+  (Join-Path $commonDesktop $gui),
+  (Join-Path $commonDesktop $cli),
+  (Join-Path $startMenu 'Octave' | Join-Path -ChildPath $gui),
+  (Join-Path $startMenu 'Octave' | Join-Path -ChildPath $cli),
+  (Join-Path $commonStartMenu 'Octave' | Join-Path -ChildPath $gui)
+  (Join-Path $commonStartMenu 'Octave' | Join-Path -ChildPath $cli)
+)
+
+# Remove any shortcuts
+$paths.GetEnumerator() | ForEach-Object {
+  if (Test-Path -Path $_) {
+    Remove-Item $_ -ErrorAction SilentlyContinue -Force | Out-Null
+  }
+}

--- a/automatic/octave.portable/tools/chocolateyInstall.ps1
+++ b/automatic/octave.portable/tools/chocolateyInstall.ps1
@@ -1,34 +1,36 @@
-﻿$version = '6.2.0'
+﻿$ErrorActionPreference = 'Stop'
 
-$toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$progDir        = "$toolsDir\octave"
+$version = '6.2.0'
 
-$osBitness      = Get-OSArchitectureWidth
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$progDir  = "$toolsDir\octave"
+
+$osBitness = Get-OSArchitectureWidth
 
 $packageArgs = @{
-    PackageName     = 'octave.portable'
-    UnzipLocation   = $toolsDir
-    Url             = 'https://ftp.gnu.org/gnu/octave/windows/octave-6.2.0-w32.7z'
-    Url64           = 'https://ftp.gnu.org/gnu/octave/windows/octave-6.2.0-w64.7z'
-    Checksum        = '4f205b4d9c8a6f03895c4c1e1aefa4c32d2d0b290976831bd52c3ab951414081'
-    Checksum64      = '2011d03a651f29310267893633caf5d8b9394da3799da6f01c225b32630d0091'
-    ChecksumType    = 'sha256'
-    ChecksumType64  = 'sha256'
+  PackageName    = 'octave.portable'
+  UnzipLocation  = $toolsDir
+  Url            = 'https://ftp.gnu.org/gnu/octave/windows/octave-6.2.0-w32.7z'
+  Url64          = 'https://ftp.gnu.org/gnu/octave/windows/octave-6.2.0-w64.7z'
+  Checksum       = '4f205b4d9c8a6f03895c4c1e1aefa4c32d2d0b290976831bd52c3ab951414081'
+  Checksum64     = '2011d03a651f29310267893633caf5d8b9394da3799da6f01c225b32630d0091'
+  ChecksumType   = 'sha256'
+  ChecksumType64 = 'sha256'
 }
 Install-ChocolateyZipPackage @packageArgs
 
 # Rename unzipped folder
 If (Test-Path "$toolsDir\octave-$version-w$osBitness") {
-    Rename-Item -Path "$toolsDir\octave-$version-w$osBitness" -NewName "octave"
+  Rename-Item -Path "$toolsDir\octave-$version-w$osBitness" -NewName "octave"
 }
 If (Test-Path "$toolsDir\octave-$version") {
-    Rename-Item -Path "$toolsDir\octave-$version" -NewName "octave"
+  Rename-Item -Path "$toolsDir\octave-$version" -NewName "octave"
 }
 
 # Don't create shims for any executables
 $files = Get-ChildItem "$toolsDir" -include *.exe -exclude "octave-cli.exe" -recurse
 foreach ($file in $files) {
-    New-Item "$file.ignore" -type file -force | Out-Null
+  New-Item "$file.ignore" -type file -force | Out-Null
 }
 # Link batch
 Install-BinFile -Name "octave" -Path "$progDir\bin\octave-cli.exe"
@@ -37,5 +39,5 @@ Install-BinFile -Name "octave" -Path "$progDir\bin\octave-cli.exe"
 $desktop = $([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::DesktopDirectory))
 $link = Join-Path $desktop "Octave.lnk"
 if (!(Test-Path $link)) {
-    Install-ChocolateyShortcut -ShortcutFilePath "$link" -TargetPath "$progDir\octave.vbs" -WorkingDirectory "$progDir" -Arguments '--force-gui' -IconLocation "$progDir\share\octave\$version\imagelib\octave-logo.ico"
+  Install-ChocolateyShortcut -ShortcutFilePath "$link" -TargetPath "$progDir\octave.vbs" -WorkingDirectory "$progDir" -Arguments '--force-gui' -IconLocation "$progDir\share\octave\$version\imagelib\octave-logo.ico"
 }

--- a/automatic/octave.portable/tools/chocolateyInstall.ps1
+++ b/automatic/octave.portable/tools/chocolateyInstall.ps1
@@ -2,7 +2,7 @@
 
 $version = '6.2.0'
 
-$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$toolsDir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
 $progDir  = "$toolsDir\octave"
 
 $osBitness = Get-OSArchitectureWidth
@@ -17,27 +17,69 @@ $packageArgs = @{
   ChecksumType   = 'sha256'
   ChecksumType64 = 'sha256'
 }
+
 Install-ChocolateyZipPackage @packageArgs
 
 # Rename unzipped folder
 If (Test-Path "$toolsDir\octave-$version-w$osBitness") {
-  Rename-Item -Path "$toolsDir\octave-$version-w$osBitness" -NewName "octave"
+  Rename-Item -Path "$toolsDir\octave-$version-w$osBitness" -NewName 'octave'
 }
 If (Test-Path "$toolsDir\octave-$version") {
-  Rename-Item -Path "$toolsDir\octave-$version" -NewName "octave"
+  Rename-Item -Path "$toolsDir\octave-$version" -NewName 'octave'
 }
 
 # Don't create shims for any executables
-$files = Get-ChildItem "$toolsDir" -include *.exe -exclude "octave-cli.exe" -recurse
+$files = Get-ChildItem "$toolsDir" -include *.exe -recurse
 foreach ($file in $files) {
   New-Item "$file.ignore" -type file -force | Out-Null
 }
-# Link batch
-Install-BinFile -Name "octave" -Path "$progDir\bin\octave-cli.exe"
 
-# Create desktop shortcut
-$desktop = $([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::DesktopDirectory))
-$link = Join-Path $desktop "Octave.lnk"
-if (!(Test-Path $link)) {
-  Install-ChocolateyShortcut -ShortcutFilePath "$link" -TargetPath "$progDir\octave.vbs" -WorkingDirectory "$progDir" -Arguments '--force-gui' -IconLocation "$progDir\share\octave\$version\imagelib\octave-logo.ico"
+# Link batch
+$path = "$progDir\mingw$osBitness\bin\octave.bat"
+Install-BinFile -Name 'octave'     -Path $path -Command '--gui' -UseStart
+Install-BinFile -Name 'octave-cli' -Path $path -Command '--no-gui'
+
+$pp = Get-PackageParameters
+
+if ($pp.Count -gt 0) {
+  $paths = New-Object System.Collections.ArrayList
+
+  if ($pp.DesktopIcon) {
+    if ($pp.LocalUser) {
+      $desktop = [Environment]::GetFolderPath('Desktop')
+    } else {
+      $desktop = [Environment]::GetFolderPath('CommonDesktopDirectory')
+    }
+
+    $paths.Add($desktop) | Out-Null
+  }
+
+  if ($pp.StartMenu) {
+    if ($pp.LocalUser) {
+      $startMenu = Join-Path ([Environment]::GetFolderPath('StartMenu')) 'Octave'
+    } else {
+      $startMenu = Join-Path ([Environment]::GetFolderPath('CommonStartMenu')) 'Octave'
+    }
+
+    $paths.Add($startMenu) | Out-Null
+  }
+
+  if ($paths.Count -gt 0) {
+    $icon   = "$progDir\mingw$osBitness\share\octave\$version\imagelib\octave-logo.ico"
+    $target = "$progDir\octave.vbs"
+
+    $paths.GetEnumerator() | foreach-object {
+      $gui = Join-Path $_ 'Octave.lnk'
+      $cli = Join-Path $_ 'Octave CLI.lnk'
+
+      if (-Not (Test-Path $gui)) {
+        Install-ChocolateyShortcut -ShortcutFilePath $gui -TargetPath $target -WorkingDirectory '%userprofile%' -IconLocation $icon
+      }
+
+      if (-Not (Test-Path $cli)) {
+        Install-ChocolateyShortcut -ShortcutFilePath $cli -TargetPath $target -WorkingDirectory '%userprofile%' -Arguments '--no-gui' -IconLocation $icon
+      }
+
+    }
+  }
 }

--- a/automatic/octave.portable/tools/chocolateyUninstall.ps1
+++ b/automatic/octave.portable/tools/chocolateyUninstall.ps1
@@ -1,14 +1,8 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$progDir  = "$toolsDir\octave"
-
-# Remove desktop shortcut
-$desktop = $([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::DesktopDirectory))
-$link = Join-Path $desktop "Octave.lnk"
-If (Test-Path $link) {
-  Remove-Item "$link"
-}
+$osBitness = Get-OSArchitectureWidth
+$path      = "$progDir\mingw$osBitness\bin\octave.bat"
 
 # Unlink batch
-Uninstall-BinFile -Name "octave" -Path "$progDir\bin\octave-cli.exe"
+Uninstall-BinFile -Name 'octave'     -Path $path
+Uninstall-BinFile -Name 'octave-cli' -Path $path

--- a/automatic/octave.portable/tools/chocolateyUninstall.ps1
+++ b/automatic/octave.portable/tools/chocolateyUninstall.ps1
@@ -1,11 +1,13 @@
-﻿$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$progDir    = "$toolsDir\octave"
+﻿$ErrorActionPreference = 'Stop'
+
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$progDir  = "$toolsDir\octave"
 
 # Remove desktop shortcut
 $desktop = $([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::DesktopDirectory))
 $link = Join-Path $desktop "Octave.lnk"
 If (Test-Path $link) {
-    Remove-Item "$link"
+  Remove-Item "$link"
 }
 
 # Unlink batch


### PR DESCRIPTION
## Description
The octave.portable package was not operating correctly.  The desktop icon and
the shims were not launching the package correctly following an install and
there was no icon available for the package.

## Motivation and Context
This change is required to bring the package to currency given changes in the
directory structure and launch parameters. Without these changes the package
does not operate as expected.

The issues with the package were caused by updates to the required
parameters and directory structure for the package and an incorrect shim
which did not configure an envrionment appropriately being installed.
To address these issues a number of changes were made:
* Update desktop icon parameters - desktop icon not launching Octave
as `--force-gui` is no longer a supported parameter
* Repoint shim from `octave-cli.exe` to `octave.bat` - launching directly
through `octave-cli.exe` fails to correctly initialize the environment and
leads to octave not functioning correctly
* Update the working directory set for shortcuts to the user profile
rather than the package install directory

In addition to the changes made to ensure the package launched correctly
some functional change were made.  These consisted of:
* Make desktop shortcut installation optional
* Support shortcut installation on the start menu
* Add a shortcut for the Octave CLI
* Add support for shortcut isntallation as a local user
* Document new package parameters

Fixes #1676

## How Has this Been Tested?
* Validating the package using cnc
* Add and remove the built package in the Chocolatey test environment
   - installed and removed with the 8 possible permutations of the package parameters
   - validated that the package launched as expected using each shortcut and shim
   - validated that shortcuts were removed on uninstall

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
