### PR TITLE
(k9s) Updated K9s script to handle both types of asset names

### DIFF
--- a/automatic/k9s/tools/chocolateyinstall.ps1
+++ b/automatic/k9s/tools/chocolateyinstall.ps1
@@ -5,7 +5,7 @@ $toolsDir      = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
   PackageName    = $packageName
-  FileFullPath64 = Get-Item $toolsDir\k9s_*_Windows_x86_64.tar.gz
+  FileFullPath64 = Get-Item $toolsDir\k9s_*Windows_x86_64.tar.gz
   Destination    = $toolsDir
 }
 
@@ -13,10 +13,10 @@ Get-ChocolateyUnzip @packageArgs
 
 $packageArgs2 = @{
   PackageName    = $packageName
-  FileFullPath64 = Get-Item $toolsDir\k9s_*_Windows_x86_64.tar
+  FileFullPath64 = Get-Item $toolsDir\k9s_*Windows_x86_64.tar
   Destination    = $toolsDir
 }
 
 Get-ChocolateyUnzip @packageArgs2
 
-Remove-Item "$toolsDir\k9s_*_Windows_*.tar"
+Remove-Item "$toolsDir\k9s_*Windows_*.tar"

--- a/automatic/k9s/update.ps1
+++ b/automatic/k9s/update.ps1
@@ -34,7 +34,11 @@ function global:au_GetLatest {
 
   $checksumAsset = $domain + ($download_page.Links | ? href -match "checksums\.txt$" | select -first 1 -expand href)
   $checksum_page = Invoke-WebRequest -Uri $checksumAsset -UseBasicParsing
-  $filename64 = -join('k9s_v', $version, '_Windows_x86_64.tar.gz')
+  if($VersionStyle -eq 0) {
+    $filename64 = 'k9s_Windows_x86_64.tar.gz'
+  } elseif ($VersionStyle -eq 1) {
+    $filename64 = -join('k9s_v', $version, '_Windows_x86_64.tar.gz')
+  }
   $checksum64 = [regex]::Match($checksum_page, "([a-f\d]+)\s*$([regex]::Escape($filename64))").Groups[1].Value
 
   return @{
@@ -47,4 +51,13 @@ function global:au_GetLatest {
   }
 }
 
-update -ChecksumFor none -Force:$Force
+$global:VersionStyle = $null
+
+try {
+  $global:VersionStyle = 0
+  update -ChecksumFor none -Force:$Force
+}
+catch {
+  $global:VersionStyle = 1
+  update -ChecksumFor none -Force:$Force
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->
k9s has changed the format of the asset files in version 0.24.10 which led me to create the PR #1668 to handle the change. The maintainer then decided to revert back that change. This PR handles both types of asset names incase the maintainer decides to change the name again.
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->
Pre `0.24.10`, the asset was called `k9s_Windows_x86_64.tar.gz`. On `0.24.10` onwards it was called `k9s_v0.24.10_Windows_x86_64.tar.gz` and in `0.24.11` to `0.24.13`, they have reverted back to `k9s_Windows_x86_64.tar.gz`.  The PR solves this by generating the asset file name first by excluding the version name and on failure including the version name.
## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
I have tested this locally by running `update.ps1` and it is able to fetch the latest file and update the relevant metadata. I am running Windows 10 Pro with PS version 5.1.
I have also tested on `chocolatey-test-environment` and `vagrant provision` is successful without errors.
## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
