### PR TITLE
(1password) Update 1Password name

### DIFF
--- a/automatic/1password/1password.nuspec
+++ b/automatic/1password/1password.nuspec
@@ -17,12 +17,12 @@
 
 ## Notes
 
-- This package provides only the latest version of 1password. If there is a need for the 4.x version of 1password, please install the [1password4](https://chocolatey.org/packages/1password4) package instead.
+- This package provides only the latest version of 1Password. If there is a need for the 4.x version of 1Password, please install the [1password4](https://chocolatey.org/packages/1password4) package instead.
 
 ![screenshot](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/automatic/1password/screenshot.png?raw=true)
 ]]></description>
     <summary>1Password - Have you ever forgotten a password?</summary>
-    <copyright>©2018 AgileBits, Inc. All rights reserved.</copyright>
+    <copyright>©2021 AgileBits, Inc. All rights reserved.</copyright>
     <tags>1password password keystore keys saver admin trial cross-platform</tags>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/1password</packageSourceUrl>
     <dependencies>

--- a/automatic/1password/Readme.md
+++ b/automatic/1password/Readme.md
@@ -1,9 +1,9 @@
-# [<img src="https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@09451a71b28e4ee0b3ea3841ab130b1bbf46f9b0/icons/1password.png" height="48" width="48" /> 1password](https://chocolatey.org/packages/1password)
+# [<img src="https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@09451a71b28e4ee0b3ea3841ab130b1bbf46f9b0/icons/1password.png" height="48" width="48" /> 1Password](https://chocolatey.org/packages/1password)
 
 1Password can create strong, unique passwords for you, remember them, and restore them, all directly in your web browser.
 
 ## Notes
 
-- This package provides only the latest version of 1password. If there is a need for the 4.x version of 1password, please install the [1password4](https://chocolatey.org/packages/1password4) package instead.
+- This package provides only the latest version of 1Password. If there is a need for the 4.x version of 1Password, please install the [1password4](https://chocolatey.org/packages/1password4) package instead.
 
 ![screenshot](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/automatic/1password/screenshot.png?raw=true)


### PR DESCRIPTION
## Description
Updated the 1Password name in the description to match the spelling of the name on the official website.

## Motivation and Context
So that the name in the description on Chocolatey Community matches the official name.

## How Has this Been Tested?
I haven't tested it in any way, but my changes concern only the description, so there should be no problems.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
