### PR TITLE
smartftp - removed vcredist dependency

### DIFF
--- a/automatic/smartftp/smartftp.nuspec
+++ b/automatic/smartftp/smartftp.nuspec
@@ -56,9 +56,6 @@
     <licenseUrl>https://www.smartftp.com/static/Products/Client/License.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@128baf7c0c572f390b16f649bae4c4b2fbeac28f/icons/smartftp.svg</iconUrl>
-    <dependencies>
-      <dependency id="vcredist140" version="14.12.25810.0" />
-    </dependencies>
     <packageSourceUrl>https://github.com/chocolatey-community/chocolatey-coreteampackages/tree/master/automatic/smartftp</packageSourceUrl>
     <docsUrl>https://www.smartftp.com/support</docsUrl>
   </metadata>


### PR DESCRIPTION
## Description
The latest version of SmartFTP no longer requires vcredist:
"The Visual C++ Redistributable Package (vcredist) is no longer installed."
https://www.smartftp.com/en-us/changelog/1

## How Has this Been Tested?
Manual

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)