### PR TITLE
smartftp: Minimum OSVersion is Windows 10 Build 14393

### DIFF
--- a/automatic/smartftp/tools/chocolateyInstall.ps1
+++ b/automatic/smartftp/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-if ([System.Environment]::OSVersion.Version -lt (new-object 'Version' 6, 3)) {
+if ([System.Environment]::OSVersion.Version -lt (new-object 'Version' 10, 0, 14393)) {
   $packageName = 'smartftp'
-  $errorMessage = 'Your Windows version is not suitable for this package. This package is only for Windows 8.1 or higher'
+  $errorMessage = 'Your Windows version is not suitable for this package. This package is only for Windows 10 Version 1607 or higher'
   Write-Output $packageName $errorMessage
   throw $errorMessage
 }


### PR DESCRIPTION
Version 10.x of the product requires Windows 10 Version 1607 or higher:
"Windows 10 1607 (Anniversary Update) or newer is required."
Reference: https://www.smartftp.com/en-us/changelog/1