### PR TITLE
(firefox) Improve the method of detecting system locale

### DIFF
--- a/automatic/firefox/tools/helpers.ps1
+++ b/automatic/firefox/tools/helpers.ps1
@@ -43,7 +43,9 @@ function GetLocale {
   $systemLocalizeAndCountry = (Get-UICulture).Name
   $systemLocaleTwoLetter = (Get-UICulture).TwoLetterISOLanguageName
   Write-Verbose "System locale is: '$systemLocalizeAndCountry'..."
-  $fallbackLocale = 'en-US'
+  $Response = Invoke-WebRequest 'https://www.mozilla.org/' -UseBasicParsing -Headers @{'Accept-Language'=$systemLocalizeAndCountry} -MaximumRedirection 0 -ErrorAction Ignore
+  $fallbackLocale = $Response.Headers.Location.Trim('/')
+  Write-Verbose "Fallback locale is: '$fallbackLocale'..."
 
   $locales = $localeFromPackageParameters,$localeFromPackageParametersTwoLetter, `
     $alreadyInstalledLocale, $systemLocalizeAndCountry, $systemLocaleTwoLetter, `


### PR DESCRIPTION
The current method of detecting system locale is not robust enough. Take "zh-HK" as an example, it should be fallback to "zh_TW", but this package fallback "zh-HK" to "en-US". This commit detects fallback locale by sending `Accept-Language: zh-HK` header to https://www.mozilla.org/ to get Mozilla fallback locale.
