### PR TITLE
(Thunderbird) Update docsUrl to new location

### DIFF
--- a/automatic/thunderbird/thunderbird.nuspec
+++ b/automatic/thunderbird/thunderbird.nuspec
@@ -10,7 +10,7 @@
     <licenseUrl>https://www.mozilla.org/en-US/about/legal/terms/thunderbird/</licenseUrl>
     <projectUrl>https://www.mozilla.org/en/thunderbird/</projectUrl>
     <projectSourceUrl>https://hg.mozilla.org/comm-central</projectSourceUrl>
-    <docsUrl>https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird</docsUrl>
+    <docsUrl>https://developer.thunderbird.net</docsUrl>
     <bugTrackerUrl>https://bugzilla.mozilla.org/</bugTrackerUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/chocolatey-community/chocolatey-coreteampackages@edba4a5849ff756e767cba86641bea97ff5721fe/icons/thunderbird.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
## Description
docsUrl now points to https://developer.thunderbird.net

## Motivation and Context

The Thunderbird docs have moved off MDN after the recent reshuffle there. The old docsUrl is now 404ing,
which causes the automatic updates of Thunderbird on Chocolatey to fail verification. This change fixes the
'The DocsUrl element in the nuspec file should be a valid Url' error during verification.

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
Not tested, but only an update to a string in .nuspec file

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

