### PR TITLE
(k9s) Use new structure for url

### DIFF
--- a/automatic/k9s/tools/chocolateyinstall.ps1
+++ b/automatic/k9s/tools/chocolateyinstall.ps1
@@ -5,7 +5,7 @@ $toolsDir      = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
   PackageName    = $packageName
-  FileFullPath64 = Get-Item $toolsDir\k9s_*_Windows_x86_64.tar.gz
+  FileFullPath64 = Get-Item $toolsDir\k9s_*Windows_x86_64.tar.gz
   Destination    = $toolsDir
 }
 
@@ -13,10 +13,10 @@ Get-ChocolateyUnzip @packageArgs
 
 $packageArgs2 = @{
   PackageName    = $packageName
-  FileFullPath64 = Get-Item $toolsDir\k9s_*_Windows_x86_64.tar
+  FileFullPath64 = Get-Item $toolsDir\k9s_*Windows_x86_64.tar
   Destination    = $toolsDir
 }
 
 Get-ChocolateyUnzip @packageArgs2
 
-Remove-Item "$toolsDir\k9s_*_Windows_*.tar"
+Remove-Item "$toolsDir\k9s_*Windows_*.tar*"

--- a/automatic/k9s/update.ps1
+++ b/automatic/k9s/update.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param([switch] $Force)
 
 Import-Module AU
@@ -31,14 +31,16 @@ function global:au_GetLatest {
   $url = $download_page.links | ? href -match $re | % href | select -First 1
 
   $version = (Split-Path ( Split-Path $url ) -Leaf).Substring(1)
+  $filename64 = Split-Path $url -Leaf
 
   $checksumAsset = $domain + ($download_page.Links | ? href -match "checksums\.txt$" | select -first 1 -expand href)
   $checksum_page = Invoke-WebRequest -Uri $checksumAsset -UseBasicParsing
+
   $checksum64 = [regex]::Match($checksum_page, "([a-f\d]+)\s*$([regex]::Escape($filename64))").Groups[1].Value
 
   return @{
     Version        = $version
-    URL64          = "$domain/derailed/k9s/releases/download/v${version}/k9s_Windows_x86_64.tar.gz"
+    URL64          = "$domain/derailed/k9s/releases/download/v${version}/${filename64}" 
     ReleaseNotes   = "$domain/derailed/k9s/blob/v${version}/change_logs/release_v${version}.md"
     ReleaseURL     = "$domain/derailed/k9s/releases/tag/v${version}"
     Checksum64     = $checksum64

--- a/automatic/k9s/update.ps1
+++ b/automatic/k9s/update.ps1
@@ -1,4 +1,4 @@
-﻿[CmdletBinding()]
+[CmdletBinding()]
 param([switch] $Force)
 
 Import-Module AU


### PR DESCRIPTION
This is basically a continuation of already existing PR #1685. If this gets approved and merged, that another one can be removed (I do not want to step on anyone's toes though). Also solves #1712.

k9s has changed the format of the asset files in version 0.24.10. The maintainer later then decided to revert back that change. This PR handles both types of asset names in case the maintainer decides to change the name again.

## Description

## Motivation and Context
Pre 0.24.10, the asset was called k9s_Windows_x86_64.tar.gz. On 0.24.10 onwards it was called k9s_v0.24.10_Windows_x86_64.tar.gz and in 0.24.11 to 0.24.15, they have reverted back to k9s_Windows_x86_64.tar.gz. The PR solves this by generating the asset file name first by excluding the version name and on failure including the version name.

## How Has this Been Tested?
Tested this locally by running update.ps1 and it is able to fetch the latest file and update the relevant metadata. I am running Windows 10 Pro with PS version 5.1.
Also tested on chocolatey-test-environment and vagrant provision is successful without errors (ran `update.ps1`, copied whole k9s folder to test environment and ran install/upgrade/downgrade).

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).