### PR TITLE
#1717 install inkscape.com as part of inkscape package

### DIFF
--- a/automatic/inkscape/tools/chocolateyInstall.ps1
+++ b/automatic/inkscape/tools/chocolateyInstall.ps1
@@ -49,7 +49,8 @@ Get-ChildItem $toolsPath\*.msi | ForEach-Object { Remove-Item $_ -ea 0; if (Test
 $packageName = $packageArgs.packageName
 $installLocation = Get-AppInstallLocation $packageArgs['softwareName']
 if ($installLocation) {
-  Install-BinFile 'inkscape' $installLocation\bin\inkscape.exe
+  Install-BinFile 'inkscape.exe' $installLocation\bin\inkscape.exe
+  Install-BinFile 'inkscape.com' $installLocation\bin\inkscape.com
   Write-Host "$packageName installed to '$installLocation'"
 }
 else { Write-Warning "Can't find $PackageName install location" }


### PR DESCRIPTION
## Description
 - #1717

## Motivation and Context
 - #1717

## How Has this Been Tested?
 - TODO

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).

<!-- The following section can be removed if the package has not been migrated from another location -->
## Original Location
- [Original Repository](add_link_to_original_repository_location)
- [Open Issues](link_to_the_generic_location_of_open_issues) *Add the different issues underneath, and tick those that are fixed in this PR*
  - [ ] Issue 1 link
  - [ ] Issue 2 Link
- [ ] *Include the link to the opened PR that removes the package from the original location*
- [ ] The [migration guidelines](https://github.com/chocolatey-community/chocolatey-coreteampackages/wiki/Package-migration-process) have been followed
